### PR TITLE
🔒 Fix mutable shared config mutation in API wrapper

### DIFF
--- a/congress_api/core/api_wrapper.py
+++ b/congress_api/core/api_wrapper.py
@@ -8,7 +8,7 @@ parameter sanitization, and standardized error responses.
 import asyncio
 import logging
 from typing import Dict, Any, Optional, List
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from fastmcp import Context
 
 from .client_handler import make_api_request
@@ -226,13 +226,13 @@ class DefensiveAPIWrapper:
         if params is None:
             params = {}
         
-        # Get endpoint configuration
+        # Get endpoint configuration (copy to avoid mutating shared ENDPOINT_CONFIGS)
         if endpoint_type:
-            config = DefensiveAPIWrapper.ENDPOINT_CONFIGS.get(endpoint_type, DefensiveAPIWrapper.ENDPOINT_CONFIGS['default'])
+            config = replace(DefensiveAPIWrapper.ENDPOINT_CONFIGS.get(endpoint_type, DefensiveAPIWrapper.ENDPOINT_CONFIGS['default']))
         else:
-            config = DefensiveAPIWrapper._get_endpoint_config(endpoint)
+            config = replace(DefensiveAPIWrapper._get_endpoint_config(endpoint))
         
-        # Apply overrides
+        # Apply overrides (safe — config is a copy)
         if timeout_override:
             config.timeout = timeout_override
         if retry_count_override is not None:


### PR DESCRIPTION
## ISSUE-02: Fix Mutable Shared Config Bug

`safe_api_request()` mutated shared `APIEndpointConfig` instances in `ENDPOINT_CONFIGS` when applying timeout/retry overrides. This permanently changed the config for all subsequent requests using that endpoint type.

### Fix
Use `dataclasses.replace()` to create a copy before applying overrides.

### Files changed
- `congress_api/core/api_wrapper.py` — 2 lines changed

### Impact
- No functionality changes
- Prevents config corruption under concurrent requests
- Existing behavior preserved

*— Mogg 🦾*