### PR TITLE
🏗️ Migrate from third-party fastmcp to official mcp SDK

### DIFF
--- a/congress_api/core/api_wrapper.py
+++ b/congress_api/core/api_wrapper.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 from typing import Dict, Any, Optional, List
 from dataclasses import dataclass, replace
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 
 from .client_handler import make_api_request
 from .exceptions import APIErrorResponse, format_error_response

--- a/congress_api/core/auth/auth.py
+++ b/congress_api/core/auth/auth.py
@@ -190,8 +190,8 @@ def check_feature_access(feature: str, tier: str) -> bool:
 # --- FastMCP Tier Authorization Decorators ---
 
 from functools import wraps
-from fastmcp import Context
-from fastmcp.exceptions import ToolError
+from mcp.server.fastmcp import Context
+from mcp.server.fastmcp.exceptions import ToolError
 
 def get_user_tier_from_context(ctx: Context) -> str:
     """
@@ -200,7 +200,7 @@ def get_user_tier_from_context(ctx: Context) -> str:
     """
     try:
         # Use FastMCP's dependency system to access HTTP request
-        from fastmcp.server.dependencies import get_http_request
+        from mcp.server.fastmcp.server.dependencies import get_http_request
         try:
             request = get_http_request()
             if hasattr(request, 'scope') and 'user' in request.scope:

--- a/congress_api/core/client_handler.py
+++ b/congress_api/core/client_handler.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 
-from fastmcp import FastMCP, Context
+from mcp.server.fastmcp import FastMCP, Context
 from .api_config import API_KEY, BASE_URL, ENABLE_CACHING, CACHE_TIMEOUT, DEFAULT_REQUEST_PARAMS, ENV
 
 # Configure logger

--- a/congress_api/features/amendments_resources.py
+++ b/congress_api/features/amendments_resources.py
@@ -2,7 +2,7 @@
 from typing import Dict, Any
 import json
 import logging
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.api_wrapper import DefensiveAPIWrapper
 

--- a/congress_api/features/bills_resources.py
+++ b/congress_api/features/bills_resources.py
@@ -6,7 +6,7 @@ including bill types, Congress ranges, status definitions, and usage guides.
 All operational bill functions have been moved to the bills/ module.
 """
 
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 
 # --- MCP Resources ---

--- a/congress_api/features/bound_congressional_record.py
+++ b/congress_api/features/bound_congressional_record.py
@@ -7,7 +7,7 @@ search functionality and individual record retrieval.
 
 import logging
 from typing import Optional, Dict, Any
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 
 from ..core.client_handler import make_api_request
 from ..core.validators import BoundCongressionalRecordValidator, ParameterValidator

--- a/congress_api/features/buckets/amendments/api.py
+++ b/congress_api/features/buckets/amendments/api.py
@@ -7,7 +7,7 @@ helpers, processors, and formatters to create API-faithful functions.
 
 import logging
 from typing import Optional
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from .processors import AmendmentsDataProcessor
 from .formatters import AmendmentsFormatter
 from ....core.validators import ParameterValidator

--- a/congress_api/features/buckets/bills/api.py
+++ b/congress_api/features/buckets/bills/api.py
@@ -7,7 +7,7 @@ to Congress.gov endpoints while maintaining enhancement capabilities.
 
 from typing import Optional
 import logging
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 
 # Import our modular components
 from .helpers import fetch_bill_data, build_bill_endpoint, validate_api_parameters

--- a/congress_api/features/buckets/bills/helpers.py
+++ b/congress_api/features/buckets/bills/helpers.py
@@ -7,7 +7,7 @@ without any business logic or formatting concerns.
 
 from typing import Dict, Optional, Any
 import logging
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 
 # Import existing validation and API infrastructure
 from ....core.validators import ParameterValidator

--- a/congress_api/features/buckets/committee_intelligence.py
+++ b/congress_api/features/buckets/committee_intelligence.py
@@ -14,8 +14,8 @@ Operation-level access control ensures granular tier-based access within the buc
 
 import logging
 from typing import Optional, Dict, Any
-from fastmcp import Context
-from fastmcp.exceptions import ToolError
+from mcp.server.fastmcp import Context
+from mcp.server.fastmcp.exceptions import ToolError
 from ...mcp_app import mcp
 
 # Import access control utilities

--- a/congress_api/features/buckets/legislation_hub.py
+++ b/congress_api/features/buckets/legislation_hub.py
@@ -12,8 +12,8 @@ Universal access model provides competitive advantage through generous freemium 
 
 import logging
 from typing import Optional, Dict, Any
-from fastmcp import Context
-from fastmcp.exceptions import ToolError
+from mcp.server.fastmcp import Context
+from mcp.server.fastmcp.exceptions import ToolError
 from ...mcp_app import mcp
 
 # Import existing tool functions - we'll import them directly to convert to internal callables

--- a/congress_api/features/buckets/members_and_committees.py
+++ b/congress_api/features/buckets/members_and_committees.py
@@ -12,8 +12,8 @@ Access control infrastructure maintained for potential future tier differentiati
 
 import logging
 from typing import Optional, Dict, Any
-from fastmcp import Context
-from fastmcp.exceptions import ToolError
+from mcp.server.fastmcp import Context
+from mcp.server.fastmcp.exceptions import ToolError
 from ...mcp_app import mcp
 
 # Import access control utilities

--- a/congress_api/features/buckets/records_and_hearings.py
+++ b/congress_api/features/buckets/records_and_hearings.py
@@ -14,8 +14,8 @@ Operation-level access control ensures granular tier-based access within the buc
 
 import logging
 from typing import Optional, Dict, Any
-from fastmcp import Context
-from fastmcp.exceptions import ToolError
+from mcp.server.fastmcp import Context
+from mcp.server.fastmcp.exceptions import ToolError
 from ...mcp_app import mcp
 
 # Import access control utilities

--- a/congress_api/features/buckets/research_and_professional.py
+++ b/congress_api/features/buckets/research_and_professional.py
@@ -14,8 +14,8 @@ Operation-level access control ensures granular tier-based access within the buc
 
 import logging
 from typing import Optional, Dict, Any
-from fastmcp import Context
-from fastmcp.exceptions import ToolError
+from mcp.server.fastmcp import Context
+from mcp.server.fastmcp.exceptions import ToolError
 from ...mcp_app import mcp
 
 # Import access control utilities

--- a/congress_api/features/buckets/voting_and_nominations.py
+++ b/congress_api/features/buckets/voting_and_nominations.py
@@ -12,8 +12,8 @@ Access control infrastructure maintained for potential future tier differentiati
 
 import logging
 from typing import Optional, Dict, Any
-from fastmcp import Context
-from fastmcp.exceptions import ToolError
+from mcp.server.fastmcp import Context
+from mcp.server.fastmcp.exceptions import ToolError
 from ...mcp_app import mcp
 
 # Import access control utilities

--- a/congress_api/features/committee_meetings.py
+++ b/congress_api/features/committee_meetings.py
@@ -1,7 +1,7 @@
 # congress_api/features/committee_meetings.py
 import logging
 from typing import Dict, Any, Optional
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.api_wrapper import safe_committee_meetings_request
 from ..core.validators import ParameterValidator

--- a/congress_api/features/committee_prints.py
+++ b/congress_api/features/committee_prints.py
@@ -1,7 +1,7 @@
 # congress_api/features/committee_prints.py
 import logging
 from typing import Dict, List, Any, Optional
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.api_wrapper import safe_committee_prints_request

--- a/congress_api/features/committee_reports.py
+++ b/congress_api/features/committee_reports.py
@@ -3,7 +3,7 @@ import logging
 import re
 from typing import Dict, Any, Optional
 import httpx
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..core.client_handler import make_api_request
 from ..core.api_wrapper import safe_committee_reports_request
 from ..core.validators import ParameterValidator

--- a/congress_api/features/committees.py
+++ b/congress_api/features/committees.py
@@ -1,7 +1,7 @@
 # committees.py
 from typing import Dict, List, Any, Optional
 import logging
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator, ValidationResult

--- a/congress_api/features/congress_info.py
+++ b/congress_api/features/congress_info.py
@@ -3,7 +3,7 @@ from typing import Dict, Any, List, Optional, Union
 import json
 import logging
 import datetime
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator

--- a/congress_api/features/congressional_record.py
+++ b/congress_api/features/congressional_record.py
@@ -3,7 +3,7 @@ import json
 import logging
 from typing import Dict, Any, List, Optional
 from datetime import datetime
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 

--- a/congress_api/features/crs_reports.py
+++ b/congress_api/features/crs_reports.py
@@ -1,7 +1,7 @@
 # congress_api/features/crs_reports.py
 import logging
 from typing import Dict, List, Any, Optional
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator

--- a/congress_api/features/daily_congressional_record.py
+++ b/congress_api/features/daily_congressional_record.py
@@ -1,7 +1,7 @@
 # congress_api/features/daily_congressional_record.py
 import logging
 from typing import Dict, List, Any, Optional
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator

--- a/congress_api/features/hearings.py
+++ b/congress_api/features/hearings.py
@@ -1,7 +1,7 @@
 # congress_api/features/hearings.py
 import logging
 from typing import Dict, List, Any, Optional
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator, ValidationResult

--- a/congress_api/features/house_communications.py
+++ b/congress_api/features/house_communications.py
@@ -1,7 +1,7 @@
 # congress_api/features/house_communications.py
 import logging
 from typing import Dict, List, Any, Optional
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 

--- a/congress_api/features/house_requirements.py
+++ b/congress_api/features/house_requirements.py
@@ -2,7 +2,7 @@
 
 import logging
 from typing import Dict, List, Any, Optional
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator

--- a/congress_api/features/house_votes.py
+++ b/congress_api/features/house_votes.py
@@ -5,7 +5,7 @@ Handles fetching and processing House of Representatives roll call vote data fro
 from typing import Dict, List, Any, Optional
 import logging
 import json
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator, ValidationResult

--- a/congress_api/features/members.py
+++ b/congress_api/features/members.py
@@ -1,6 +1,6 @@
 # members.py
 from typing import Dict, Any, Optional
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper, safe_members_request

--- a/congress_api/features/nominations.py
+++ b/congress_api/features/nominations.py
@@ -6,7 +6,7 @@ This module provides access to nomination data from the Congress.gov API.
 
 import logging
 from typing import Dict, Any, List, Optional
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.api_wrapper import safe_nominations_request
 from ..core.validators import ParameterValidator

--- a/congress_api/features/senate_communications.py
+++ b/congress_api/features/senate_communications.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Dict, List, Any, Optional
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.api_wrapper import safe_senate_communications_request
 from ..core.validators import ParameterValidator

--- a/congress_api/features/summaries.py
+++ b/congress_api/features/summaries.py
@@ -2,7 +2,7 @@
 from typing import Dict, Any, Optional, List
 import json
 import logging
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 

--- a/congress_api/features/treaties.py
+++ b/congress_api/features/treaties.py
@@ -1,7 +1,7 @@
 # congress_api/features/treaties.py
 import logging
 from typing import Dict, List, Any, Optional
-from fastmcp import Context
+from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.api_wrapper import safe_treaties_request

--- a/congress_api/mcp_app.py
+++ b/congress_api/mcp_app.py
@@ -1,5 +1,5 @@
 # mcp_app.py
-from fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP
 from .core.cors import cors_headers
 from .core.client_handler import app_lifespan
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ charset-normalizer==3.4.2
 click==8.2.1
 exceptiongroup==1.3.0
 fastapi==0.115.12
-fastmcp==2.5.2
+# fastmcp removed — using official mcp.server.fastmcp from mcp package
 gunicorn==23.0.0
 h11==0.16.0
 httpcore==1.0.9


### PR DESCRIPTION
## ISSUE-04: SDK Migration

### Problem
CongressMCP imports from `fastmcp` (third-party package v2.5.2) when the official `mcp` package (v1.9.2, already installed) includes `mcp.server.fastmcp` with the same API.

### Fix
- Updated 34 files, 42 import replacements
- `from fastmcp import X` → `from mcp.server.fastmcp import X`
- `from fastmcp.exceptions` → `from mcp.server.fastmcp.exceptions`
- Removed `fastmcp==2.5.2` from requirements.txt
- Official `mcp==1.9.2` was already present

### Impact
- One fewer dependency to maintain
- Aligned with official MCP SDK (future updates come from the source)
- No API changes — drop-in replacement

*— Mogg 🦾*