### PR TITLE
CMCP-08: Deduplicate SubscriptionTier enum

### DIFF
--- a/congress_api/core/database.py
+++ b/congress_api/core/database.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from dateutil import parser as dateutil_parser
 from supabase import create_client, Client
 from .api_config import load_environment_config
+from .auth.auth import SubscriptionTier
 
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -36,11 +37,7 @@ def _cleanup_thread_pool():
 
 atexit.register(_cleanup_thread_pool)
 
-# Subscription tiers (matching auth.py)
-class SubscriptionTier(str, Enum):
-    FREE = "free"
-    PRO = "pro"
-    ENTERPRISE = "enterprise"
+# SubscriptionTier imported from auth.auth - single source of truth
 
 @dataclass
 class User:


### PR DESCRIPTION
Removes duplicate SubscriptionTier enum definition. Single source of truth now established in congress_api/core/auth/auth.py. All imports point to the same source. Clean code principles: DRY (Don't Repeat Yourself) achieved.