### PR TITLE
Fix: add missing chamber parameter to committee tools

### DIFF
--- a/congress_api/features/members_committees_tools.py
+++ b/congress_api/features/members_committees_tools.py
@@ -405,17 +405,19 @@ async def search_committees(
 )
 async def get_committee_bills(
     ctx: Context,
+    chamber: str,
     committee_code: str,
     limit: int = 20
 ) -> MembersCommitteesResponse:
     """
     Get bills referred to or reported by a specific committee.
-    
+
     Args:
         ctx: Context for API requests
+        chamber: Chamber of Congress ("house", "senate", or "joint")
         committee_code: Official committee code (e.g., 'HSJU', 'SSJU')
         limit: Maximum number of bills to return
-    
+
     Returns:
         List of bills associated with the committee
     """
@@ -423,6 +425,7 @@ async def get_committee_bills(
         from .committees import get_committee_bills as _get_committee_bills
         raw_response = await _get_committee_bills(
             ctx,
+            chamber=chamber,
             committee_code=committee_code,
             limit=limit
         )
@@ -445,17 +448,19 @@ async def get_committee_bills(
 )
 async def get_committee_reports(
     ctx: Context,
+    chamber: str,
     committee_code: str,
     limit: int = 20
 ) -> MembersCommitteesResponse:
     """
     Get reports issued by a specific committee.
-    
+
     Args:
         ctx: Context for API requests
+        chamber: Chamber of Congress ("house", "senate", or "joint")
         committee_code: Official committee code (e.g., 'HSJU', 'SSJU')
         limit: Maximum number of reports to return
-    
+
     Returns:
         List of reports issued by the committee
     """
@@ -463,6 +468,7 @@ async def get_committee_reports(
         from .committees import get_committee_reports as _get_committee_reports
         raw_response = await _get_committee_reports(
             ctx,
+            chamber=chamber,
             committee_code=committee_code,
             limit=limit
         )
@@ -485,17 +491,19 @@ async def get_committee_reports(
 )
 async def get_committee_communications(
     ctx: Context,
+    chamber: str,
     committee_code: str,
     limit: int = 20
 ) -> MembersCommitteesResponse:
     """
     Get communications (letters, statements) from a specific committee.
-    
+
     Args:
         ctx: Context for API requests
+        chamber: Chamber of Congress ("house", "senate", or "joint")
         committee_code: Official committee code (e.g., 'HSJU', 'SSJU')
         limit: Maximum number of communications to return
-    
+
     Returns:
         List of communications from the committee
     """
@@ -503,6 +511,7 @@ async def get_committee_communications(
         from .committees import get_committee_communications as _get_committee_communications
         raw_response = await _get_committee_communications(
             ctx,
+            chamber=chamber,
             committee_code=committee_code,
             limit=limit
         )

--- a/tests/test_chamber_param_fix.py
+++ b/tests/test_chamber_param_fix.py
@@ -1,0 +1,67 @@
+"""
+Tests that get_committee_bills, get_committee_reports, and get_committee_communications
+accept and pass through the chamber parameter correctly (Issue #26 fix).
+"""
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+
+class FakeContext:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_get_committee_bills_accepts_chamber():
+    """Tool wrapper must pass chamber through to the underlying function."""
+    from congress_api.features.members_committees_tools import get_committee_bills
+
+    mock_response = "Bills referred to House Committee hsju:\n- HR 1: Test Bill"
+    mock_convert = MagicMock(return_value=MagicMock(success=True))
+
+    with patch("congress_api.features.committees.get_committee_bills", new=AsyncMock(return_value=mock_response)) as mock_fn, \
+         patch("congress_api.features.members_committees_tools.convert_members_committees_response", mock_convert):
+        await get_committee_bills(FakeContext(), chamber="house", committee_code="hsju", limit=5)
+        mock_fn.assert_called_once()
+        call_kwargs = mock_fn.call_args.kwargs
+        assert call_kwargs["chamber"] == "house"
+        assert call_kwargs["committee_code"] == "hsju"
+
+
+@pytest.mark.asyncio
+async def test_get_committee_reports_accepts_chamber():
+    """Tool wrapper must pass chamber through to the underlying function."""
+    from congress_api.features.members_committees_tools import get_committee_reports
+
+    mock_response = "Reports from Senate Committee ssfi:"
+    mock_convert = MagicMock(return_value=MagicMock(success=True))
+
+    with patch("congress_api.features.committees.get_committee_reports", new=AsyncMock(return_value=mock_response)) as mock_fn, \
+         patch("congress_api.features.members_committees_tools.convert_members_committees_response", mock_convert):
+        await get_committee_reports(FakeContext(), chamber="senate", committee_code="ssfi", limit=5)
+        mock_fn.assert_called_once()
+        call_kwargs = mock_fn.call_args.kwargs
+        assert call_kwargs["chamber"] == "senate"
+        assert call_kwargs["committee_code"] == "ssfi"
+
+
+@pytest.mark.asyncio
+async def test_get_committee_communications_accepts_chamber():
+    """Tool wrapper must pass chamber through to the underlying function."""
+    from congress_api.features.members_committees_tools import get_committee_communications
+
+    mock_response = "Communications from House Committee hsju:"
+    mock_convert = MagicMock(return_value=MagicMock(success=True))
+
+    with patch("congress_api.features.committees.get_committee_communications", new=AsyncMock(return_value=mock_response)) as mock_fn, \
+         patch("congress_api.features.members_committees_tools.convert_members_committees_response", mock_convert):
+        await get_committee_communications(FakeContext(), chamber="house", committee_code="hsju", limit=5)
+        mock_fn.assert_called_once()
+        call_kwargs = mock_fn.call_args.kwargs
+        assert call_kwargs["chamber"] == "house"
+        assert call_kwargs["committee_code"] == "hsju"


### PR DESCRIPTION
Fixes #26

The MCP tool wrappers in `members_committees_tools.py` omitted the required
`chamber` argument for three tools, causing them to always fail with:

    missing 1 required positional argument: 'chamber'

**Affected tools:**
- `get_committee_bills`
- `get_committee_reports`
- `get_committee_communications`

**Fix:** Added `chamber` as an explicit required parameter to each tool wrapper
and passed it through to the underlying `committees.py` functions.

`get_committee_nominations` was not affected as it is Senate-only and the
underlying function does not require a chamber argument.