### PR TITLE
Fix: member tools crash on unsupported limit/current_member args (follow up to #27)

### DIFF
--- a/congress_api/features/members.py
+++ b/congress_api/features/members.py
@@ -168,13 +168,16 @@ async def get_member_details(ctx: Context, bioguide_id: str) -> str:
         logger.error(f"Error in get_member_details: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"Unexpected error: {str(e)}"))
 
-async def get_member_sponsored_legislation(ctx: Context, bioguide_id: str) -> str:
+async def get_member_sponsored_legislation(ctx: Context, bioguide_id: str, limit: int = 20, offset: int = 0) -> str:
     """
     Get legislation sponsored by a specific member of Congress.
-    
+
     Args:
         bioguide_id: The Bioguide ID for the member (e.g., "L000174")
-        
+        limit: Maximum number of results to return (default: 20, max: 250).
+               Note: returns a single page only; no date or congress filter applied.
+        offset: Zero-based offset for pagination (default: 0)
+
     Returns a list of legislation sponsored by the specified member.
     """
     try:
@@ -183,14 +186,21 @@ async def get_member_sponsored_legislation(ctx: Context, bioguide_id: str) -> st
             return format_error_response(CommonErrors.invalid_parameter(
                 "bioguide_id", bioguide_id, "Bioguide ID must be a non-empty string"
             ))
-        
+
         bioguide_id = bioguide_id.strip().upper()
         if not bioguide_id:
             return format_error_response(CommonErrors.invalid_parameter(
                 "bioguide_id", bioguide_id, "Bioguide ID cannot be empty"
             ))
-        
-        data = await safe_congressional_request(f"/member/{bioguide_id}/sponsored-legislation", ctx, {"limit": 20}, endpoint_type='members')
+
+        # Validate limit parameter
+        limit_validation = validator.validate_limit_range(limit, 250)
+        if not limit_validation.is_valid:
+            return format_error_response(CommonErrors.invalid_parameter(
+                "limit", limit, limit_validation.error_message
+            ))
+
+        data = await safe_congressional_request(f"/member/{bioguide_id}/sponsored-legislation", ctx, {"limit": limit, "offset": offset}, endpoint_type='members')
         
         if "error" in data:
             if "404" in str(data["error"]):
@@ -234,13 +244,16 @@ async def get_member_sponsored_legislation(ctx: Context, bioguide_id: str) -> st
         logger.error(f"Error in get_member_sponsored_legislation: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"Unexpected error: {str(e)}"))
 
-async def get_member_cosponsored_legislation(ctx: Context, bioguide_id: str) -> str:
+async def get_member_cosponsored_legislation(ctx: Context, bioguide_id: str, limit: int = 20, offset: int = 0) -> str:
     """
     Get legislation cosponsored by a specific member of Congress.
-    
+
     Args:
         bioguide_id: The Bioguide ID for the member (e.g., "L000174")
-        
+        limit: Maximum number of results to return (default: 20, max: 250).
+               Note: returns a single page only; no date or congress filter applied.
+        offset: Zero-based offset for pagination (default: 0)
+
     Returns a list of legislation cosponsored by the specified member.
     """
     try:
@@ -249,14 +262,21 @@ async def get_member_cosponsored_legislation(ctx: Context, bioguide_id: str) -> 
             return format_error_response(CommonErrors.invalid_parameter(
                 "bioguide_id", bioguide_id, "Bioguide ID must be a non-empty string"
             ))
-        
+
         bioguide_id = bioguide_id.strip().upper()
         if not bioguide_id:
             return format_error_response(CommonErrors.invalid_parameter(
                 "bioguide_id", bioguide_id, "Bioguide ID cannot be empty"
             ))
-        
-        data = await safe_congressional_request(f"/member/{bioguide_id}/cosponsored-legislation", ctx, {"limit": 20}, endpoint_type='members')
+
+        # Validate limit parameter
+        limit_validation = validator.validate_limit_range(limit, 250)
+        if not limit_validation.is_valid:
+            return format_error_response(CommonErrors.invalid_parameter(
+                "limit", limit, limit_validation.error_message
+            ))
+
+        data = await safe_congressional_request(f"/member/{bioguide_id}/cosponsored-legislation", ctx, {"limit": limit, "offset": offset}, endpoint_type='members')
         
         if "error" in data:
             if "404" in str(data["error"]):
@@ -300,13 +320,16 @@ async def get_member_cosponsored_legislation(ctx: Context, bioguide_id: str) -> 
         logger.error(f"Error in get_member_cosponsored_legislation: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"Unexpected error: {str(e)}"))
 
-async def get_members_by_congress(ctx: Context, congress: int) -> str:
+async def get_members_by_congress(ctx: Context, congress: int, current_member: Optional[bool] = None, limit: int = 50) -> str:
     """
     Get members of a specific Congress.
-    
+
     Args:
         congress: The Congress number (e.g., 118)
-        
+        current_member: If True, only return current members; if False, only non-current;
+                        if None (default), return all members.
+        limit: Maximum number of members to return (default: 50, max: 250)
+
     Returns a list of members who served in the specified Congress.
     """
     try:
@@ -316,9 +339,21 @@ async def get_members_by_congress(ctx: Context, congress: int) -> str:
             return format_error_response(CommonErrors.invalid_parameter(
                 "congress", congress, congress_validation.error_message
             ))
-        
+
+        # Validate limit parameter
+        limit_validation = validator.validate_limit_range(limit, 250)
+        if not limit_validation.is_valid:
+            return format_error_response(CommonErrors.invalid_parameter(
+                "limit", limit, limit_validation.error_message
+            ))
+
+        # Build base params
+        base_params: Dict[str, Any] = {}
+        if current_member is not None:
+            base_params["currentMember"] = "true" if current_member else "false"
+
         # Use pagination to get all members of the congress
-        data = await get_all_members_paginated(ctx, f"/member/congress/{congress}", {})
+        data = await get_all_members_paginated(ctx, f"/member/congress/{congress}", base_params)
         
         if "error" in data:
             return format_error_response(CommonErrors.api_server_error(f"Error retrieving members for Congress {congress}: {data['error']}"))
@@ -329,29 +364,36 @@ async def get_members_by_congress(ctx: Context, congress: int) -> str:
         
         # Process and deduplicate results
         members = response_processor.deduplicate_results(
-            members, 
+            members,
             key_fields=["bioguideId"]
         )
-        
+
+        # Apply limit
+        if len(members) > limit:
+            members = members[:limit]
+
         result = [f"# Members of the {congress}th Congress"]
         result.append(f"Found {len(members)} members:")
-        
+
         for member in members:
             result.append("\n" + format_member_summary(member))
-        
+
         return "\n".join(result)
-        
+
     except Exception as e:
         logger.error(f"Error in get_members_by_congress: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"Unexpected error: {str(e)}"))
 
-async def get_members_by_state(ctx: Context, state_code: str) -> str:
+async def get_members_by_state(ctx: Context, state_code: str, current_member: Optional[bool] = True, limit: int = 20) -> str:
     """
     Get members from a specific state.
-    
+
     Args:
         state_code: The two-letter state code (e.g., "MI" for Michigan)
-        
+        current_member: If True (default), only return current members; if False, only
+                        non-current; if None, return all members.
+        limit: Maximum number of members to return (default: 20, max: 250)
+
     Returns a list of members who represent the specified state.
     """
     try:
@@ -361,10 +403,22 @@ async def get_members_by_state(ctx: Context, state_code: str) -> str:
             return format_error_response(CommonErrors.invalid_parameter(
                 "state_code", state_code, state_validation.error_message
             ))
-        
+
         state_code = state_validation.sanitized_value
-        
-        data = await safe_congressional_request(f"/member/{state_code}", ctx, {"currentMember": "true"}, endpoint_type='members')
+
+        # Validate limit parameter
+        limit_validation = validator.validate_limit_range(limit, 250)
+        if not limit_validation.is_valid:
+            return format_error_response(CommonErrors.invalid_parameter(
+                "limit", limit, limit_validation.error_message
+            ))
+
+        # Build request params
+        params: Dict[str, Any] = {"limit": limit}
+        if current_member is not None:
+            params["currentMember"] = "true" if current_member else "false"
+
+        data = await safe_congressional_request(f"/member/{state_code}", ctx, params, endpoint_type='members')
         
         if "error" in data:
             return format_error_response(CommonErrors.api_server_error(f"Error retrieving members for state {state_code}: {data['error']}"))
@@ -391,14 +445,16 @@ async def get_members_by_state(ctx: Context, state_code: str) -> str:
         logger.error(f"Error in get_members_by_state: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"Unexpected error: {str(e)}"))
 
-async def get_members_by_district(ctx: Context, state_code: str, district: int) -> str:
+async def get_members_by_district(ctx: Context, state_code: str, district: int, current_member: Optional[bool] = True) -> str:
     """
     Get members from a specific congressional district.
-    
+
     Args:
         state_code: The two-letter state code (e.g., "MI" for Michigan)
         district: The district number (e.g., 10)
-        
+        current_member: If True (default), only return current members; if False, only
+                        non-current; if None, return all members.
+
     Returns a list of members who represent the specified district.
     """
     try:
@@ -408,16 +464,21 @@ async def get_members_by_district(ctx: Context, state_code: str, district: int) 
             return format_error_response(CommonErrors.invalid_parameter(
                 "state_code", state_code, state_validation.error_message
             ))
-        
+
         state_code = state_validation.sanitized_value
-        
+
         # Validate district parameter
         if not isinstance(district, int) or district < 1:
             return format_error_response(CommonErrors.invalid_parameter(
                 "district", district, "District must be a positive integer (e.g., 1, 2, 10)"
             ))
-        
-        data = await safe_congressional_request(f"/member/{state_code}/{district}", ctx, {"currentMember": "true"}, endpoint_type='members')
+
+        # Build request params
+        params: Dict[str, Any] = {}
+        if current_member is not None:
+            params["currentMember"] = "true" if current_member else "false"
+
+        data = await safe_congressional_request(f"/member/{state_code}/{district}", ctx, params, endpoint_type='members')
         
         if "error" in data:
             return format_error_response(CommonErrors.api_server_error(f"Error retrieving members for {state_code}-{district}: {data['error']}"))

--- a/tests/test_member_tools_arg_fix.py
+++ b/tests/test_member_tools_arg_fix.py
@@ -1,0 +1,297 @@
+"""
+Tests that member tool wrappers pass limit / current_member through to the
+underlying members.py implementation functions without TypeError.
+
+This is the member-tool equivalent of test_chamber_param_fix.py (which covers
+committee tools fixed in #26/#27).
+
+Covered:
+  - get_member_sponsored_legislation   (limit)
+  - get_member_cosponsored_legislation (limit)
+  - get_members_by_congress            (current_member, limit)
+  - get_members_by_state               (current_member, limit)
+  - get_members_by_district            (current_member)
+"""
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+
+class FakeContext:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Wrapper → underlying forwarding tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_member_sponsored_legislation_passes_limit():
+    """Wrapper must forward limit to the underlying function."""
+    from congress_api.features.members_committees_tools import get_member_sponsored_legislation
+
+    mock_response = "# Sponsored Legislation for Member K000397\nFound 5 bills:"
+    mock_convert = MagicMock(return_value=MagicMock(success=True))
+
+    with patch(
+        "congress_api.features.members.get_member_sponsored_legislation",
+        new=AsyncMock(return_value=mock_response),
+    ) as mock_fn, patch(
+        "congress_api.features.members_committees_tools.convert_members_committees_response",
+        mock_convert,
+    ):
+        await get_member_sponsored_legislation(
+            FakeContext(), bioguide_id="K000397", limit=50
+        )
+        mock_fn.assert_called_once()
+        call_kwargs = mock_fn.call_args.kwargs
+        assert call_kwargs["bioguide_id"] == "K000397"
+        assert call_kwargs["limit"] == 50
+
+
+@pytest.mark.asyncio
+async def test_get_member_cosponsored_legislation_passes_limit():
+    """Wrapper must forward limit to the underlying function."""
+    from congress_api.features.members_committees_tools import get_member_cosponsored_legislation
+
+    mock_response = "# Cosponsored Legislation for Member K000397\nFound 3 bills:"
+    mock_convert = MagicMock(return_value=MagicMock(success=True))
+
+    with patch(
+        "congress_api.features.members.get_member_cosponsored_legislation",
+        new=AsyncMock(return_value=mock_response),
+    ) as mock_fn, patch(
+        "congress_api.features.members_committees_tools.convert_members_committees_response",
+        mock_convert,
+    ):
+        await get_member_cosponsored_legislation(
+            FakeContext(), bioguide_id="K000397", limit=30
+        )
+        mock_fn.assert_called_once()
+        call_kwargs = mock_fn.call_args.kwargs
+        assert call_kwargs["bioguide_id"] == "K000397"
+        assert call_kwargs["limit"] == 30
+
+
+@pytest.mark.asyncio
+async def test_get_members_by_congress_passes_current_member_and_limit():
+    """Wrapper must forward current_member and limit to the underlying function."""
+    from congress_api.features.members_committees_tools import get_members_by_congress
+
+    mock_response = "# Members of the 118th Congress\nFound 10 members:"
+    mock_convert = MagicMock(return_value=MagicMock(success=True))
+
+    with patch(
+        "congress_api.features.members.get_members_by_congress",
+        new=AsyncMock(return_value=mock_response),
+    ) as mock_fn, patch(
+        "congress_api.features.members_committees_tools.convert_members_committees_response",
+        mock_convert,
+    ):
+        await get_members_by_congress(
+            FakeContext(), congress=118, current_member=True, limit=25
+        )
+        mock_fn.assert_called_once()
+        call_kwargs = mock_fn.call_args.kwargs
+        assert call_kwargs["congress"] == 118
+        assert call_kwargs["current_member"] is True
+        assert call_kwargs["limit"] == 25
+
+
+@pytest.mark.asyncio
+async def test_get_members_by_state_passes_current_member_and_limit():
+    """Wrapper must forward current_member and limit to the underlying function."""
+    from congress_api.features.members_committees_tools import get_members_by_state
+
+    mock_response = "# Members from CA\nFound 2 current members:"
+    mock_convert = MagicMock(return_value=MagicMock(success=True))
+
+    with patch(
+        "congress_api.features.members.get_members_by_state",
+        new=AsyncMock(return_value=mock_response),
+    ) as mock_fn, patch(
+        "congress_api.features.members_committees_tools.convert_members_committees_response",
+        mock_convert,
+    ):
+        await get_members_by_state(
+            FakeContext(), state_code="CA", current_member=False, limit=10
+        )
+        mock_fn.assert_called_once()
+        call_kwargs = mock_fn.call_args.kwargs
+        assert call_kwargs["state_code"] == "CA"
+        assert call_kwargs["current_member"] is False
+        assert call_kwargs["limit"] == 10
+
+
+@pytest.mark.asyncio
+async def test_get_members_by_district_passes_current_member():
+    """Wrapper must forward current_member to the underlying function."""
+    from congress_api.features.members_committees_tools import get_members_by_district
+
+    mock_response = "# Members from CA District 39\nFound 1 current members:"
+    mock_convert = MagicMock(return_value=MagicMock(success=True))
+
+    with patch(
+        "congress_api.features.members.get_members_by_district",
+        new=AsyncMock(return_value=mock_response),
+    ) as mock_fn, patch(
+        "congress_api.features.members_committees_tools.convert_members_committees_response",
+        mock_convert,
+    ):
+        await get_members_by_district(
+            FakeContext(), state_code="CA", district=39, current_member=False
+        )
+        mock_fn.assert_called_once()
+        call_kwargs = mock_fn.call_args.kwargs
+        assert call_kwargs["state_code"] == "CA"
+        assert call_kwargs["district"] == 39
+        assert call_kwargs["current_member"] is False
+
+
+# ---------------------------------------------------------------------------
+# Limit reaches safe_congressional_request
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sponsored_legislation_limit_reaches_api():
+    """A caller-supplied limit must reach the API params dict."""
+    from congress_api.features.members import get_member_sponsored_legislation
+
+    mock_data = {"sponsoredLegislation": []}
+
+    with patch(
+        "congress_api.features.members.safe_congressional_request",
+        new=AsyncMock(return_value=mock_data),
+    ) as mock_req:
+        await get_member_sponsored_legislation(FakeContext(), bioguide_id="K000397", limit=100)
+        mock_req.assert_called_once()
+        _, _, params = mock_req.call_args.args
+        assert params["limit"] == 100
+
+
+@pytest.mark.asyncio
+async def test_cosponsored_legislation_limit_reaches_api():
+    """A caller-supplied limit must reach the API params dict."""
+    from congress_api.features.members import get_member_cosponsored_legislation
+
+    mock_data = {"cosponsoredLegislation": []}
+
+    with patch(
+        "congress_api.features.members.safe_congressional_request",
+        new=AsyncMock(return_value=mock_data),
+    ) as mock_req:
+        await get_member_cosponsored_legislation(FakeContext(), bioguide_id="K000397", limit=75)
+        mock_req.assert_called_once()
+        _, _, params = mock_req.call_args.args
+        assert params["limit"] == 75
+
+
+# ---------------------------------------------------------------------------
+# Limit > 250 is rejected
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sponsored_legislation_limit_over_250_rejected():
+    """limit > 250 must return an error, not raise TypeError."""
+    from congress_api.features.members import get_member_sponsored_legislation
+
+    result = await get_member_sponsored_legislation(
+        FakeContext(), bioguide_id="K000397", limit=999
+    )
+    assert "error" in result.lower() or "invalid" in result.lower() or "limit" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_cosponsored_legislation_limit_over_250_rejected():
+    """limit > 250 must return an error, not raise TypeError."""
+    from congress_api.features.members import get_member_cosponsored_legislation
+
+    result = await get_member_cosponsored_legislation(
+        FakeContext(), bioguide_id="K000397", limit=300
+    )
+    assert "error" in result.lower() or "invalid" in result.lower() or "limit" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Regression: underlying functions accept the new kwargs without TypeError
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_underlying_sponsored_accepts_limit_and_offset():
+    """Regression: get_member_sponsored_legislation(ctx, bioguide_id, limit, offset) — no TypeError."""
+    from congress_api.features.members import get_member_sponsored_legislation
+
+    with patch(
+        "congress_api.features.members.safe_congressional_request",
+        new=AsyncMock(return_value={"sponsoredLegislation": []}),
+    ):
+        # Must not raise TypeError
+        result = await get_member_sponsored_legislation(
+            FakeContext(), bioguide_id="K000397", limit=10, offset=5
+        )
+    assert isinstance(result, str)
+
+
+@pytest.mark.asyncio
+async def test_underlying_cosponsored_accepts_limit_and_offset():
+    """Regression: get_member_cosponsored_legislation(ctx, bioguide_id, limit, offset) — no TypeError."""
+    from congress_api.features.members import get_member_cosponsored_legislation
+
+    with patch(
+        "congress_api.features.members.safe_congressional_request",
+        new=AsyncMock(return_value={"cosponsoredLegislation": []}),
+    ):
+        result = await get_member_cosponsored_legislation(
+            FakeContext(), bioguide_id="K000397", limit=10, offset=0
+        )
+    assert isinstance(result, str)
+
+
+@pytest.mark.asyncio
+async def test_underlying_members_by_congress_accepts_current_member_and_limit():
+    """Regression: get_members_by_congress(ctx, congress, current_member, limit) — no TypeError."""
+    from congress_api.features.members import get_members_by_congress
+
+    with patch(
+        "congress_api.features.members.get_all_members_paginated",
+        new=AsyncMock(return_value={"members": []}),
+    ):
+        result = await get_members_by_congress(
+            FakeContext(), congress=118, current_member=True, limit=50
+        )
+    assert isinstance(result, str)
+
+
+@pytest.mark.asyncio
+async def test_underlying_members_by_state_accepts_current_member_and_limit():
+    """Regression: get_members_by_state(ctx, state_code, current_member, limit) — no TypeError."""
+    from congress_api.features.members import get_members_by_state
+
+    with patch(
+        "congress_api.features.members.safe_congressional_request",
+        new=AsyncMock(return_value={"members": []}),
+    ):
+        result = await get_members_by_state(
+            FakeContext(), state_code="CA", current_member=True, limit=20
+        )
+    assert isinstance(result, str)
+
+
+@pytest.mark.asyncio
+async def test_underlying_members_by_district_accepts_current_member():
+    """Regression: get_members_by_district(ctx, state_code, district, current_member) — no TypeError."""
+    from congress_api.features.members import get_members_by_district
+
+    with patch(
+        "congress_api.features.members.safe_congressional_request",
+        new=AsyncMock(return_value={"members": []}),
+    ):
+        result = await get_members_by_district(
+            FakeContext(), state_code="CA", district=39, current_member=True
+        )
+    assert isinstance(result, str)


### PR DESCRIPTION
## Summary
Five MCP tool wrappers in `members_committees_tools.py` pass keyword arguments (`limit`, `current_member`) that the matching `members.py` implementation functions never declared, causing every call to fail with `TypeError: <fn>() got an unexpected keyword argument`. Same defect class as #26/#27, on the member-tool family.
## Affected tools
- `get_member_sponsored_legislation` — wrapper passes `limit`, underlying ignored it
- `get_member_cosponsored_legislation` — same
- `get_members_by_congress` — wrapper passes `current_member` and `limit`, underlying ignored both
- `get_members_by_state` — same
- `get_members_by_district` — wrapper passes `current_member`, underlying ignored it
## Fix
Added the missing params to the `members.py` functions and threaded them into the Congress.gov request (`limit`, `offset`, `currentMember`). `limit` validated against the API max of 250. Verified with a live call (bioguide K000397, limit=250 → 107 bills).
## Limitations
- Sponsored/cosponsored fetch a single page only (no offset loop); results span all Congresses with no date filter — caller must filter.