### PR TITLE
feat: auto-derive chamber from committee code prefix when not provided

### DIFF
--- a/congress_api/features/committees.py
+++ b/congress_api/features/committees.py
@@ -189,21 +189,49 @@ async def get_committee_details(ctx: Context, chamber: str, committee_code: str)
 # - get_committee_communications: Communications with limit parameter
 # - search_committees: Search functionality
 
+def _infer_chamber_from_code(committee_code: str) -> str | None:
+    """
+    Infer chamber from committee code prefix.
+    House codes start with 'hs', Senate with 'ss' or 's', Joint with 'j'.
+    Returns None if the prefix is unrecognized.
+    """
+    code = committee_code.lower()
+    if code.startswith("hs"):
+        return "house"
+    elif code.startswith("ss"):
+        return "senate"
+    elif code.startswith("j"):
+        return "joint"
+    elif code.startswith("s"):
+        return "senate"
+    elif code.startswith("h"):
+        return "house"
+    return None
+
+
 async def get_committee_bills(
     ctx: Context,
-    chamber: str,
     committee_code: str,
+    chamber: str | None = None,
     limit: int = 10
 ) -> str:
     """
     Get bills referred to a specific committee.
-    
+
     Args:
-        chamber: The chamber of Congress ("house" or "senate")
         committee_code: The committee code (e.g., "hsag", "ssap")
+        chamber: The chamber of Congress ("house", "senate", or "joint").
+                 If omitted, inferred from the committee code prefix.
         limit: Maximum number of bills to return (default: 10)
     """
     try:
+        # Auto-derive chamber from committee code if not provided
+        if not chamber:
+            chamber = _infer_chamber_from_code(committee_code)
+            if not chamber:
+                return f"Could not infer chamber from committee code '{committee_code}'. Please provide chamber explicitly ('house', 'senate', or 'joint')."
+            logger.info(f"Inferred chamber '{chamber}' from committee code '{committee_code}'")
+
         # Validate parameters
         chamber_validation = ParameterValidator.validate_chamber(chamber)
         if not chamber_validation.is_valid:
@@ -265,19 +293,27 @@ async def get_committee_bills(
 
 async def get_committee_reports(
     ctx: Context,
-    chamber: str,
     committee_code: str,
+    chamber: str | None = None,
     limit: int = 10
 ) -> str:
     """
     Get reports for a specific committee.
-    
+
     Args:
-        chamber: The chamber of Congress ("house" or "senate")
         committee_code: The committee code (e.g., "hspw00", "ssas00")
+        chamber: The chamber of Congress ("house", "senate", or "joint").
+                 If omitted, inferred from the committee code prefix.
         limit: Maximum number of reports to return (default: 10)
     """
     try:
+        # Auto-derive chamber from committee code if not provided
+        if not chamber:
+            chamber = _infer_chamber_from_code(committee_code)
+            if not chamber:
+                return f"Could not infer chamber from committee code '{committee_code}'. Please provide chamber explicitly ('house', 'senate', or 'joint')."
+            logger.info(f"Inferred chamber '{chamber}' from committee code '{committee_code}'")
+
         # Validate parameters
         chamber_validation = ParameterValidator.validate_chamber(chamber)
         if not chamber_validation.is_valid:
@@ -408,19 +444,27 @@ async def get_committee_nominations(
 
 async def get_committee_communications(
     ctx: Context,
-    chamber: str,
     committee_code: str,
+    chamber: str | None = None,
     limit: int = 10
 ) -> str:
     """
     Get communications for a specific committee.
-    
+
     Args:
-        chamber: The chamber of Congress ("house" or "senate")
         committee_code: The committee code (e.g., "hspw00", "ssas00")
+        chamber: The chamber of Congress ("house", "senate", or "joint").
+                 If omitted, inferred from the committee code prefix.
         limit: Maximum number of communications to return (default: 10)
     """
     try:
+        # Auto-derive chamber from committee code if not provided
+        if not chamber:
+            chamber = _infer_chamber_from_code(committee_code)
+            if not chamber:
+                return f"Could not infer chamber from committee code '{committee_code}'. Please provide chamber explicitly ('house', 'senate', or 'joint')."
+            logger.info(f"Inferred chamber '{chamber}' from committee code '{committee_code}'")
+
         # Validate parameters
         chamber_validation = ParameterValidator.validate_chamber(chamber)
         if not chamber_validation.is_valid:

--- a/congress_api/features/members_committees_tools.py
+++ b/congress_api/features/members_committees_tools.py
@@ -405,8 +405,8 @@ async def search_committees(
 )
 async def get_committee_bills(
     ctx: Context,
-    chamber: str,
     committee_code: str,
+    chamber: Optional[str] = None,
     limit: int = 20
 ) -> MembersCommitteesResponse:
     """
@@ -414,8 +414,9 @@ async def get_committee_bills(
 
     Args:
         ctx: Context for API requests
-        chamber: Chamber of Congress ("house", "senate", or "joint")
-        committee_code: Official committee code (e.g., 'HSJU', 'SSJU')
+        committee_code: Official committee code (e.g., 'hsju', 'ssju')
+        chamber: Chamber of Congress ("house", "senate", or "joint").
+                 If omitted, inferred automatically from the committee code prefix.
         limit: Maximum number of bills to return
 
     Returns:
@@ -425,8 +426,8 @@ async def get_committee_bills(
         from .committees import get_committee_bills as _get_committee_bills
         raw_response = await _get_committee_bills(
             ctx,
-            chamber=chamber,
             committee_code=committee_code,
+            chamber=chamber,
             limit=limit
         )
         return convert_members_committees_response(raw_response, "get_committee_bills")
@@ -448,8 +449,8 @@ async def get_committee_bills(
 )
 async def get_committee_reports(
     ctx: Context,
-    chamber: str,
     committee_code: str,
+    chamber: Optional[str] = None,
     limit: int = 20
 ) -> MembersCommitteesResponse:
     """
@@ -457,8 +458,9 @@ async def get_committee_reports(
 
     Args:
         ctx: Context for API requests
-        chamber: Chamber of Congress ("house", "senate", or "joint")
-        committee_code: Official committee code (e.g., 'HSJU', 'SSJU')
+        committee_code: Official committee code (e.g., 'hsju', 'ssju')
+        chamber: Chamber of Congress ("house", "senate", or "joint").
+                 If omitted, inferred automatically from the committee code prefix.
         limit: Maximum number of reports to return
 
     Returns:
@@ -468,8 +470,8 @@ async def get_committee_reports(
         from .committees import get_committee_reports as _get_committee_reports
         raw_response = await _get_committee_reports(
             ctx,
-            chamber=chamber,
             committee_code=committee_code,
+            chamber=chamber,
             limit=limit
         )
         return convert_members_committees_response(raw_response, "get_committee_reports")
@@ -491,8 +493,8 @@ async def get_committee_reports(
 )
 async def get_committee_communications(
     ctx: Context,
-    chamber: str,
     committee_code: str,
+    chamber: Optional[str] = None,
     limit: int = 20
 ) -> MembersCommitteesResponse:
     """
@@ -500,8 +502,9 @@ async def get_committee_communications(
 
     Args:
         ctx: Context for API requests
-        chamber: Chamber of Congress ("house", "senate", or "joint")
-        committee_code: Official committee code (e.g., 'HSJU', 'SSJU')
+        committee_code: Official committee code (e.g., 'hsju', 'ssju')
+        chamber: Chamber of Congress ("house", "senate", or "joint").
+                 If omitted, inferred automatically from the committee code prefix.
         limit: Maximum number of communications to return
 
     Returns:
@@ -511,8 +514,8 @@ async def get_committee_communications(
         from .committees import get_committee_communications as _get_committee_communications
         raw_response = await _get_committee_communications(
             ctx,
-            chamber=chamber,
             committee_code=committee_code,
+            chamber=chamber,
             limit=limit
         )
         return convert_members_committees_response(raw_response, "get_committee_communications")

--- a/tests/test_chamber_param_fix.py
+++ b/tests/test_chamber_param_fix.py
@@ -1,6 +1,7 @@
 """
 Tests that get_committee_bills, get_committee_reports, and get_committee_communications
-accept and pass through the chamber parameter correctly (Issue #26 fix).
+accept and pass through the chamber parameter correctly (Issue #26 fix), and that
+chamber can be auto-derived from the committee code prefix when omitted.
 """
 import asyncio
 import os
@@ -60,8 +61,47 @@ async def test_get_committee_communications_accepts_chamber():
 
     with patch("congress_api.features.committees.get_committee_communications", new=AsyncMock(return_value=mock_response)) as mock_fn, \
          patch("congress_api.features.members_committees_tools.convert_members_committees_response", mock_convert):
-        await get_committee_communications(FakeContext(), chamber="house", committee_code="hsju", limit=5)
+        await get_committee_communications(FakeContext(), committee_code="hsju", chamber="house", limit=5)
         mock_fn.assert_called_once()
         call_kwargs = mock_fn.call_args.kwargs
         assert call_kwargs["chamber"] == "house"
         assert call_kwargs["committee_code"] == "hsju"
+
+
+# --- Auto-derive tests ---
+
+@pytest.mark.asyncio
+async def test_infer_chamber_house():
+    from congress_api.features.committees import _infer_chamber_from_code
+    assert _infer_chamber_from_code("hsju") == "house"
+    assert _infer_chamber_from_code("hspw00") == "house"
+
+@pytest.mark.asyncio
+async def test_infer_chamber_senate():
+    from congress_api.features.committees import _infer_chamber_from_code
+    assert _infer_chamber_from_code("ssju") == "senate"
+    assert _infer_chamber_from_code("ssfi") == "senate"
+    assert _infer_chamber_from_code("sssb") == "senate"
+
+@pytest.mark.asyncio
+async def test_infer_chamber_joint():
+    from congress_api.features.committees import _infer_chamber_from_code
+    assert _infer_chamber_from_code("jslc") == "joint"
+
+@pytest.mark.asyncio
+async def test_get_committee_bills_no_chamber_auto_derives():
+    """When chamber is omitted, it should be inferred from the committee code."""
+    from congress_api.features.members_committees_tools import get_committee_bills
+
+    mock_response = "Bills referred to House Committee hsag:"
+    mock_convert = MagicMock(return_value=MagicMock(success=True))
+
+    with patch("congress_api.features.committees.get_committee_bills", new=AsyncMock(return_value=mock_response)) as mock_fn, \
+         patch("congress_api.features.members_committees_tools.convert_members_committees_response", mock_convert):
+        # No chamber provided - should infer "house" from "hsag"
+        await get_committee_bills(FakeContext(), committee_code="hsag", limit=5)
+        mock_fn.assert_called_once()
+        # The underlying function receives committee_code and chamber=None;
+        # auto-derive happens inside committees.py itself
+        call_kwargs = mock_fn.call_args.kwargs
+        assert call_kwargs["committee_code"] == "hsag"


### PR DESCRIPTION
## Summary

Builds on #27 by making `chamber` optional on `get_committee_bills`, `get_committee_reports`, and `get_committee_communications`. When omitted, chamber is inferred from the committee code prefix (`hs*` → house, `ss*`/`s*` → senate, `j*` → joint), so callers that don't supply chamber still succeed instead of erroring.

## Changes
- Added `_infer_chamber_from_code()` helper in `committees.py`
- Made `chamber` optional (default `None`) on the three functions and their wrappers
- 4 new tests covering house/senate/joint inference and the no-chamber path (7 total, all passing)