### PR TITLE
Fix: get_committee_bills returned empty for all committees

### DIFF
--- a/congress_api/features/committees.py
+++ b/congress_api/features/committees.py
@@ -225,7 +225,7 @@ async def get_committee_bills(
             logger.warning(f"API error for committee bills: {response['error']}")
             return response["error"]
         
-        bills = response.get("bills", [])
+        bills = response.get("committee-bills", {}).get("bills", [])
         if not bills:
             return f"No bills found for committee {committee_code} in the {chamber.capitalize()}."
         
@@ -238,20 +238,15 @@ async def get_committee_bills(
         # Format results
         result = [f"Bills referred to {chamber.capitalize()} Committee {committee_code}:"]
         for bill in bills[:limit]:
-            title = bill.get("title", "No title available")
             bill_type = bill.get("type", "Unknown")
             number = bill.get("number", "Unknown")
             congress = bill.get("congress", "Unknown")
             url = bill.get("url", "No URL available")
-            
-            # Get latest action
-            latest_action = bill.get("latestAction", {})
-            action_date = latest_action.get("actionDate", "Unknown")
-            action_text = latest_action.get("text", "No action text")
-            
+            relationship = bill.get("relationshipType", "Unknown")
+            action_date = bill.get("actionDate", "Unknown")
+
             result.append(f"\n**{bill_type.upper()} {number}** (Congress {congress})")
-            result.append(f"Title: {title}")
-            result.append(f"Latest Action ({action_date}): {action_text}")
+            result.append(f"Relationship: {relationship} ({action_date})")
             result.append(f"URL: {url}")
         
         logger.info(f"Successfully retrieved {len(bills)} bills for committee {committee_code}")


### PR DESCRIPTION
## Problem
`get_committee_bills` always returned "No bills found" for every committee, even ones with tens of thousands of referred bills (e.g. `hsju00` = 41,578; `sseg00` = 11,217).

## Root cause
The Congress.gov committee-bills endpoint nests results under `committee-bills.bills`:

```json
{ "committee-bills": { "bills": [ ... ], "count": 41578 } }
```

…but the tool read the top-level `bills` key, which never exists, so it always fell through to the empty-result branch. (`get_committee_reports` works because *its* endpoint really does return `reports` at the top level — that asymmetry hid the bug.)

## Fix
- Read `response["committee-bills"]["bills"]`.
- Format using the fields this endpoint actually returns (`relationshipType`, `actionDate`) instead of `title`/`latestAction`, which it does not include.

Verified against the live API; existing committee/member test suites pass (21 tests).
