### PR TITLE
Fix: make keywords optional on search_committees and search_summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Sign up at **[api.congress.gov/sign-up](https://api.congress.gov/sign-up/)** (ta
 | **Voting & Nominations** | 13 | House/Senate votes, nominations, roll calls |
 | **Records & Hearings** | 10+ | Congressional Record, hearings, CRS reports, committee prints |
 
+`search_committees` and `search_summaries` take an **optional** `keywords` argument —
+omit it to browse/list (committees can also be filtered by `chamber`/`committee_type`).
+
 ## Running from source
 
 ```bash

--- a/congress_api/features/committees.py
+++ b/congress_api/features/committees.py
@@ -523,61 +523,87 @@ async def get_committee_communications(
 
 async def search_committees(
     ctx: Context,
-    keywords: str,
+    keywords: Optional[str] = None,
     chamber: Optional[str] = None,
     congress: Optional[int] = None,
+    committee_type: Optional[str] = None,
     limit: int = 10
 ) -> str:
     """
-    Search for committees based on keywords.
-    
+    Search for / browse congressional committees.
+
     Args:
-        keywords: Keywords to search for in committee information
+        keywords: Optional keywords to search for in committee information.
+                  When omitted, lists committees (optionally filtered by chamber).
         chamber: Optional chamber of Congress ("house", "senate", or "joint")
         congress: Optional Congress number (e.g., 117)
+        committee_type: Optional committee type to filter on (e.g. "standing",
+                        "select"), matched against the committee's type name.
         limit: Maximum number of results to return (default: 10)
     """
     try:
+        keywords = keywords.strip() if isinstance(keywords, str) else None
+
         # Validate parameters
         if chamber and chamber.lower() not in ["house", "senate", "joint"]:
             logger.warning(f"Invalid chamber: {chamber}")
             return f"Invalid chamber '{chamber}'. Must be 'house', 'senate', or 'joint'."
-            
+
         if congress:
             congress_validation = ParameterValidator.validate_congress_number(congress)
             if not congress_validation.is_valid:
                 logger.warning(f"Invalid congress number: {congress}")
                 return congress_validation.error_message
-                
+
         limit_validation = ParameterValidator.validate_limit_range(limit)
         if not limit_validation.is_valid:
             logger.warning(f"Invalid limit: {limit}")
             return limit_validation.error_message
-        
-        # Build search parameters
-        params = {"q": keywords, "limit": limit}
-        if chamber:
-            params["chamber"] = chamber.lower()
-        if congress:
-            params["congress"] = congress
-        
+
+        # The /committee endpoint ignores q/chamber/congress query params, so chamber
+        # is filtered via the PATH and keywords/type are filtered client-side.
+        # (congress is accepted for compatibility but the committee list endpoint is
+        # not congress-scoped; the congress-path variants are intentionally omitted.)
+        chamber_l = chamber.lower() if chamber else None
+        endpoint = f"/committee/{chamber_l}" if chamber_l in ("house", "senate", "joint") else "/committee"
+
+        # Fetch a large page when filtering client-side; the API caps limit at 250.
+        need_filter = bool(keywords or committee_type)
+        params = {"limit": 250 if need_filter else limit}
+
         # Make API request
-        response = await safe_committees_request("/committee", ctx, params)
-        
+        response = await safe_committees_request(endpoint, ctx, params)
+
         if "error" in response:
             logger.warning(f"API error for committee search: {response['error']}")
             return response["error"]
-        
+
         committees = response.get("committees", [])
+
+        # Client-side keyword filter (name / systemCode) — the endpoint has no `q`.
+        if keywords:
+            kw = keywords.lower()
+            committees = [
+                c for c in committees
+                if kw in (c.get("name") or "").lower() or kw in (c.get("systemCode") or "").lower()
+            ]
+        # Client-side type filter against committeeTypeCode (e.g. Standing/Select/Joint).
+        if committee_type:
+            ct = committee_type.lower()
+            committees = [c for c in committees if ct in (c.get("committeeTypeCode") or "").lower()]
+
+        descriptor = f" matching '{keywords}'" if keywords else ""
+        if committee_type:
+            descriptor += f" (type: {committee_type})"
         if not committees:
-            return f"No committees found matching '{keywords}'."
-        
+            return f"No committees found{descriptor}."
+
         # Format results
-        result = [f"Committees matching '{keywords}':"]
+        result = [f"Committees{descriptor}:"]
         for committee in committees[:limit]:
             result.append("\n" + format_committee_summary(committee))
-        
-        logger.info(f"Successfully found {len(committees)} committees for search '{keywords}'")
+
+        logger.info(f"Successfully found {len(committees)} committees (search='{keywords}', type='{committee_type}')")
         return "\n".join(result)
         
     except Exception as e:

--- a/congress_api/features/members_committees_tools.py
+++ b/congress_api/features/members_committees_tools.py
@@ -362,19 +362,24 @@ async def get_members_by_congress_state_district(
 )
 async def search_committees(
     ctx: Context,
+    keywords: Optional[str] = None,
     chamber: Optional[str] = None,
     committee_type: Optional[str] = None,
+    congress: Optional[int] = None,
     limit: int = 20
 ) -> MembersCommitteesResponse:
     """
-    Search for congressional committees.
-    
+    Search for / browse congressional committees.
+
     Args:
         ctx: Context for API requests
+        keywords: Optional keywords to search committee information. When omitted,
+                  lists committees (optionally filtered by chamber/type).
         chamber: Chamber ('House', 'Senate', or 'Joint')
         committee_type: Type of committee ('Standing', 'Select', etc.)
+        congress: Optional Congress number (e.g., 119)
         limit: Maximum number of committees to return
-    
+
     Returns:
         List of matching committees with basic information
     """
@@ -382,7 +387,9 @@ async def search_committees(
         from .committees import search_committees as _search_committees
         raw_response = await _search_committees(
             ctx,
+            keywords=keywords,
             chamber=chamber,
+            congress=congress,
             committee_type=committee_type,
             limit=limit
         )

--- a/congress_api/features/summaries.py
+++ b/congress_api/features/summaries.py
@@ -466,8 +466,8 @@ async def get_summaries_api_info(ctx: Context) -> str:
 # @require_paid_access
 async def search_summaries(
     ctx: Context,
-    keywords: str, 
-    congress: Optional[int] = None, 
+    keywords: Optional[str] = None,
+    congress: Optional[int] = None,
     bill_type: Optional[str] = None,
     limit: int = 10,
     sort: str = "updateDate+desc",
@@ -489,12 +489,9 @@ async def search_summaries(
     logger.info(f"Searching for summaries with keywords: {keywords}")
     
     try:
-        # Parameter validation
-        if not keywords or not keywords.strip():
-            return format_error_response(
-                CommonErrors.invalid_parameter("keywords", keywords, "Keywords cannot be empty", ["climate change", "healthcare", "defense"])
-            )
-        
+        # keywords is optional: when omitted, browse recent summaries unfiltered.
+        keywords = keywords.strip() if isinstance(keywords, str) else None
+
         # Validate limit
         limit_validation = ParameterValidator.validate_limit_range(limit, 250)
         if not limit_validation.is_valid:
@@ -567,18 +564,26 @@ async def search_summaries(
         
         if not summaries:
             return f"No summaries found for the specified criteria."
-        
-        # Client-side filtering based on keywords using processor
-        filtered_summaries = SummariesProcessor.filter_by_keywords(summaries, keywords)
-        
+
+        # Client-side keyword filtering only when a keyword was supplied; otherwise
+        # browse the recent summaries list as-is.
+        if keywords:
+            filtered_summaries = SummariesProcessor.filter_by_keywords(summaries, keywords)
+            title = f"Bill Summaries Matching '{keywords}'"
+            empty_msg = f"No summaries found matching '{keywords}'."
+        else:
+            filtered_summaries = summaries
+            title = "Recent Bill Summaries"
+            empty_msg = "No summaries found for the specified criteria."
+
         # Limit the results to the requested number
         filtered_summaries = filtered_summaries[:limit]
-        
+
         if not filtered_summaries:
-            return f"No summaries found matching '{keywords}'."
-        
-        logger.info(f"Found {len(filtered_summaries)} summaries matching '{keywords}'")
-        return format_summaries_list(filtered_summaries, f"Bill Summaries Matching '{keywords}'")
+            return empty_msg
+
+        logger.info(f"Found {len(filtered_summaries)} summaries ({'keyword' if keywords else 'browse'} mode)")
+        return format_summaries_list(filtered_summaries, title)
         
     except Exception as e:
         logger.error(f"Error searching summaries with keywords '{keywords}': {str(e)}")

--- a/tests/test_signature_fixes.py
+++ b/tests/test_signature_fixes.py
@@ -1,0 +1,84 @@
+"""
+Mocked regression tests for the Batch-1 signature fixes:
+- search_committees: keywords optional (browse mode), committee_type filters
+  client-side, and the tool wrapper no longer crashes forwarding committee_type.
+- search_summaries: keywords optional (browse mode), no "keywords cannot be empty".
+
+These patch the API layer so they run offline and fast.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+class FakeContext:
+    pass
+
+
+_COMMITTEES = {
+    "committees": [
+        {"name": "Judiciary Committee", "chamber": "House", "systemCode": "hsju00",
+         "committeeTypeCode": "Standing", "url": "u1"},
+        {"name": "Select Committee on Intelligence", "chamber": "House", "systemCode": "hlig00",
+         "committeeTypeCode": "Select", "url": "u2"},
+    ]
+}
+
+
+@pytest.mark.asyncio
+async def test_search_committees_browse_without_keywords():
+    """Impl must not require keywords; browsing returns committees."""
+    from congress_api.features import committees
+    with patch.object(committees, "safe_committees_request", new=AsyncMock(return_value=_COMMITTEES)):
+        result = await committees.search_committees(FakeContext(), chamber="house", limit=10)
+    assert "Judiciary Committee" in result
+    assert "cannot be empty" not in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_search_committees_keyword_filters_clientside():
+    from congress_api.features import committees
+    with patch.object(committees, "safe_committees_request", new=AsyncMock(return_value=_COMMITTEES)):
+        result = await committees.search_committees(FakeContext(), keywords="judiciary", limit=10)
+    assert "Judiciary Committee" in result
+    assert "Intelligence" not in result
+
+
+@pytest.mark.asyncio
+async def test_search_committees_type_filters_clientside():
+    from congress_api.features import committees
+    with patch.object(committees, "safe_committees_request", new=AsyncMock(return_value=_COMMITTEES)):
+        select = await committees.search_committees(FakeContext(), committee_type="select", limit=10)
+        standing = await committees.search_committees(FakeContext(), committee_type="standing", limit=10)
+    assert "Intelligence" in select and "Judiciary" not in select
+    assert "Judiciary" in standing and "Intelligence" not in standing
+
+
+@pytest.mark.asyncio
+async def test_search_committees_wrapper_forwards_committee_type_without_crash():
+    """The #1 regression: wrapper forwarding committee_type used to crash the impl."""
+    from congress_api.features import members_committees_tools as mct
+    with patch("congress_api.features.committees.safe_committees_request",
+               new=AsyncMock(return_value=_COMMITTEES)):
+        resp = await mct.search_committees(FakeContext(), chamber="House",
+                                           committee_type="Standing", limit=10)
+    # wrapper returns a structured response; success means no exception path
+    assert resp.success is True
+    assert resp.operation == "search_committees"
+
+
+@pytest.mark.asyncio
+async def test_search_summaries_optional_keywords_no_empty_error():
+    """search_summaries must browse without keywords (no 'cannot be empty')."""
+    from congress_api.features import summaries
+    payload = {"summaries": [{"bill": {"congress": 119, "type": "HR", "number": "1",
+                                        "title": "Test"}, "actionDate": "2025-01-01",
+                              "text": "A summary", "updateDate": "2025-01-02"}]}
+    with patch.object(summaries, "safe_congressional_request", new=AsyncMock(return_value=payload)):
+        result = await summaries.search_summaries(FakeContext(), congress=119, limit=5)
+    assert "cannot be empty" not in result.lower()
+    assert "Recent Bill Summaries" in result or "summaries" in result.lower()

--- a/tests/test_wrapper_impl_signatures.py
+++ b/tests/test_wrapper_impl_signatures.py
@@ -1,0 +1,85 @@
+"""
+Static wrapper -> impl signature conformance.
+
+The live audit harness probes impls directly, so it is structurally BLIND to
+wrapper/impl signature mismatches (the #28 / search_committees class: a tool
+wrapper forwarding a kwarg the impl doesn't accept, or omitting a required one).
+This test closes that gap with zero network: for each delegating wrapper in
+members_committees_tools, it extracts the kwargs the wrapper forwards to its impl
+(via AST) and asserts (a) every forwarded kwarg is accepted by the impl, and
+(b) every required impl param is forwarded.
+"""
+import ast
+import importlib
+import inspect
+import textwrap
+
+import congress_api.features.members_committees_tools as mct
+
+# wrapper tool name -> (impl module under congress_api.features, impl func name)
+DELEGATIONS = {
+    "search_members": ("members", "search_members"),
+    "get_member_details": ("members", "get_member_details"),
+    "get_member_sponsored_legislation": ("members", "get_member_sponsored_legislation"),
+    "get_member_cosponsored_legislation": ("members", "get_member_cosponsored_legislation"),
+    "get_members_by_congress": ("members", "get_members_by_congress"),
+    "get_members_by_state": ("members", "get_members_by_state"),
+    "get_members_by_district": ("members", "get_members_by_district"),
+    "get_members_by_congress_state_district": ("members", "get_members_by_congress_state_district"),
+    "search_committees": ("committees", "search_committees"),
+    "get_committee_bills": ("committees", "get_committee_bills"),
+    "get_committee_reports": ("committees", "get_committee_reports"),
+    "get_committee_communications": ("committees", "get_committee_communications"),
+    "get_committee_nominations": ("committees", "get_committee_nominations"),
+}
+
+
+def _forwarded_kwargs(wrapper_fn):
+    """Return the set of keyword names the wrapper forwards in its impl call.
+
+    Finds the awaited call whose first positional arg is `ctx` (the impl
+    delegation) and collects its keyword argument names.
+    """
+    src = textwrap.dedent(inspect.getsource(wrapper_fn))
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if node.args and isinstance(node.args[0], ast.Name) and node.args[0].id == "ctx":
+            return {kw.arg for kw in node.keywords if kw.arg is not None}
+    return set()
+
+
+def _impl(mod, fn):
+    module = importlib.import_module(f"congress_api.features.{mod}")
+    return getattr(module, fn)
+
+
+def test_wrappers_forward_only_accepted_kwargs():
+    """No wrapper may forward a kwarg the impl doesn't accept (the #28 class)."""
+    failures = []
+    for tool, (mod, fn) in DELEGATIONS.items():
+        impl_params = set(inspect.signature(_impl(mod, fn)).parameters)
+        forwarded = _forwarded_kwargs(getattr(mct, tool))
+        extra = forwarded - impl_params
+        if extra:
+            failures.append(f"{tool} -> {mod}.{fn} forwards unaccepted kwargs: {sorted(extra)}")
+    assert not failures, "\n".join(failures)
+
+
+def test_wrappers_supply_all_required_impl_params():
+    """Every required impl param (no default) must be forwarded by the wrapper."""
+    failures = []
+    for tool, (mod, fn) in DELEGATIONS.items():
+        sig = inspect.signature(_impl(mod, fn))
+        required = {
+            name for name, p in sig.parameters.items()
+            if name != "ctx"
+            and p.default is inspect.Parameter.empty
+            and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+        }
+        forwarded = _forwarded_kwargs(getattr(mct, tool))
+        missing = required - forwarded
+        if missing:
+            failures.append(f"{tool} -> {mod}.{fn} missing required params: {sorted(missing)}")
+    assert not failures, "\n".join(failures)


### PR DESCRIPTION
Both tools required a keyword, so browsing/listing crashed: search_summaries raised a ToolError ("missing 1 required positional argument: 'keywords'") and search_committees' wrapper also forwarded an unsupported committee_type kwarg.

Make `keywords` optional on both (browse mode when omitted). For search_committees, filter chamber via the path (`/committee/{chamber}`) and keywords/committee_type client-side, since the /committee endpoint ignores those query params; realign the wrapper signature. Adds mocked regression tests plus a static wrapper->impl signature check to catch this class of mismatch.