### PR TITLE
Fix: bill formatters crash on null fields from the live API

### DIFF
--- a/congress_api/features/buckets/bills/api.py
+++ b/congress_api/features/buckets/bills/api.py
@@ -625,7 +625,9 @@ async def get_bill_subjects(
         if "error" in response:
             return str(response["error"])
 
-        subjects = response.get('subjects', [])
+        # The API returns subjects as a dict {legislativeSubjects, policyArea};
+        # the formatter handles that shape (and a legacy list) directly.
+        subjects = response.get('subjects', {})
         return BillsFormatter.format_bill_subjects(subjects)
 
     except Exception as e:

--- a/congress_api/features/buckets/bills/formatters.py
+++ b/congress_api/features/buckets/bills/formatters.py
@@ -75,9 +75,9 @@ class BillsFormatter:
             if "title" in bill:
                 result.append(f"**Title:** {bill['title']}")
 
-            # Latest action
-            if "latestAction" in bill:
-                action = bill["latestAction"]
+            # Latest action (the API may return latestAction as null for some bills)
+            action = bill.get("latestAction")
+            if isinstance(action, dict):
                 result.append(f"**Latest Action:** {action.get('text', 'Unknown')} ({action.get('actionDate', 'Unknown date')})")
 
             # URL
@@ -119,29 +119,29 @@ class BillsFormatter:
                 sponsor_names = [s.get("fullName", "Unknown") for s in sponsors]
                 result.append(f"**Sponsor{'s' if len(sponsor_names) > 1 else ''}:** {', '.join(sponsor_names)}")
 
-            # Cosponsors
-            if "cosponsors" in bill and "count" in bill["cosponsors"]:
+            # Cosponsors (dict-valued fields can be null in the API response)
+            if isinstance(bill.get("cosponsors"), dict) and "count" in bill["cosponsors"]:
                 result.append(f"**Cosponsors:** {bill['cosponsors']['count']}")
 
             # Latest Action
-            if "latestAction" in bill:
-                action = bill["latestAction"]
+            action = bill.get("latestAction")
+            if isinstance(action, dict):
                 result.append(f"**Latest Action:** {action.get('text', 'Unknown')} ({action.get('actionDate', 'Unknown date')})")
 
             # Committees
-            if "committees" in bill and "count" in bill["committees"]:
+            if isinstance(bill.get("committees"), dict) and "count" in bill["committees"]:
                 result.append(f"**Committees:** {bill['committees']['count']}")
 
             # Policy Area
-            if "policyArea" in bill and "name" in bill["policyArea"]:
+            if isinstance(bill.get("policyArea"), dict) and "name" in bill["policyArea"]:
                 result.append(f"**Policy Area:** {bill['policyArea']['name']}")
 
             # Subjects
-            if "subjects" in bill and "count" in bill["subjects"]:
+            if isinstance(bill.get("subjects"), dict) and "count" in bill["subjects"]:
                 result.append(f"**Subjects:** {bill['subjects']['count']}")
 
             # Text Versions
-            if "textVersions" in bill and "count" in bill["textVersions"] and bill["textVersions"]["count"] > 0:
+            if isinstance(bill.get("textVersions"), dict) and "count" in bill["textVersions"] and bill["textVersions"]["count"] > 0:
                 result.append("**Text Versions Available:** Use get_bill_text_versions tool for text versions.")
 
             # URL
@@ -294,25 +294,37 @@ class BillsFormatter:
             return f"Error formatting cosponsors: {str(e)}"
 
     @staticmethod
-    def format_bill_subjects(subjects: List[Dict[str, Any]]) -> str:
+    def format_bill_subjects(subjects: Any) -> str:
         """
         Format bill subjects into a readable list.
 
         Args:
-            subjects: List of subject dictionaries
+            subjects: The API `subjects` value — a dict of the form
+                ``{"legislativeSubjects": [...], "policyArea": {...}}`` (current
+                live shape), or a plain list of subject dicts (legacy).
 
         Returns:
             Formatted subjects list
         """
         try:
-            if not subjects:
+            policy_area = None
+            if isinstance(subjects, dict):
+                policy_area = subjects.get("policyArea")
+                subjects = subjects.get("legislativeSubjects", [])
+            if not isinstance(subjects, list):
+                subjects = []
+
+            if not subjects and not isinstance(policy_area, dict):
                 return "No subjects found."
 
             result = ["## Bill Subjects", ""]
+            if isinstance(policy_area, dict) and policy_area.get("name"):
+                result.append(f"**Policy Area:** {policy_area['name']}")
+                result.append("")
 
             for subject in subjects:
-                name = subject.get('name', 'Unknown subject')
-                result.append(f"- {name}")
+                if isinstance(subject, dict):
+                    result.append(f"- {subject.get('name', 'Unknown subject')}")
 
             return "\n".join(result)
 

--- a/tests/test_formatter_fixes.py
+++ b/tests/test_formatter_fixes.py
@@ -1,0 +1,67 @@
+"""
+Mocked regression tests for the Batch-2 formatter fixes (pure unit tests).
+
+- format_bill_summary / format_bills_list must not crash when the API returns
+  `latestAction: null` (the get_bills 'NoneType' object has no attribute 'get').
+- format_bill_detail must tolerate null dict-valued fields (cosponsors, etc.).
+- format_bill_subjects must handle the live dict shape
+  {legislativeSubjects:[...], policyArea:{...}} (the get_bill_subjects
+  'str' object has no attribute 'get'), and a legacy list.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from congress_api.features.buckets.bills.formatters import BillsFormatter
+
+
+def test_bill_summary_tolerates_null_latest_action():
+    bill = {"type": "HR", "number": "6", "congress": 119,
+            "title": "Reserved", "latestAction": None, "url": "u"}
+    out = BillsFormatter.format_bill_summary(bill)
+    assert "Error formatting" not in out
+    assert "HR 6" in out
+
+
+def test_bills_list_tolerates_null_latest_action():
+    resp = {"bills": [
+        {"type": "HR", "number": "6", "congress": 119, "latestAction": None, "url": "u"},
+        {"type": "HR", "number": "9", "congress": 119,
+         "latestAction": {"text": "Referred", "actionDate": "2025-01-03"}, "url": "u2"},
+    ]}
+    out = BillsFormatter.format_bills_list(resp, "Bills")
+    assert "Error formatting" not in out
+    assert "HR 6" in out and "HR 9" in out
+    assert "Referred" in out
+
+
+def test_bill_detail_tolerates_null_dict_fields():
+    bill = {"type": "HR", "number": "1", "congress": 119, "title": "Test",
+            "cosponsors": None, "committees": None, "policyArea": None,
+            "subjects": None, "latestAction": None, "textVersions": None}
+    out = BillsFormatter.format_bill_detail(bill)
+    assert "Error formatting" not in out
+    assert "HR 1" in out
+
+
+def test_bill_subjects_handles_live_dict_shape():
+    subjects = {
+        "legislativeSubjects": [{"name": "Abortion"}, {"name": "Accounting and auditing"}],
+        "policyArea": {"name": "Economics and Public Finance"},
+    }
+    out = BillsFormatter.format_bill_subjects(subjects)
+    assert "Error formatting" not in out
+    assert "Policy Area:** Economics and Public Finance" in out
+    assert "- Abortion" in out
+
+
+def test_bill_subjects_handles_legacy_list():
+    out = BillsFormatter.format_bill_subjects([{"name": "Taxation"}])
+    assert "Error formatting" not in out
+    assert "- Taxation" in out
+
+
+def test_bill_subjects_empty():
+    assert BillsFormatter.format_bill_subjects({}) == "No subjects found."
+    assert BillsFormatter.format_bill_subjects([]) == "No subjects found."


### PR DESCRIPTION
The /bill listing returns latestAction: null for some bills (e.g. under sort=updateDate+desc), and dict-valued fields (cosponsors, committees, etc.) can also be null — format_bill_summary/format_bill_detail then raised "'NoneType' object has no attribute 'get'". get_bill_subjects also passed the API's subjects dict ({legislativeSubjects, policyArea}) into a list formatter, raising "'str' object has no attribute 'get'".

Guard null/non-dict fields in the formatters and teach format_bill_subjects to render the dict shape (policy area + legislative subjects), with a legacy-list fallback. Adds pure-unit regression tests.