### PR TITLE
Fix: wrong endpoints in committee/member tools (live API conformance)

### DIFF
--- a/congress_api/features/committee_meetings.py
+++ b/congress_api/features/committee_meetings.py
@@ -399,15 +399,19 @@ async def search_committee_meetings(
         if scheduled_to:
             params["scheduledTo"] = scheduled_to
         
-        # Determine the endpoint based on provided parameters
+        # Determine the endpoint. The committee-meeting endpoint only supports
+        # /{congress}/{chamber} filtering; the 4th path segment is {eventId}, NOT a
+        # committee code, so appending committee_code 404s. The meeting LIST items
+        # also carry no committee code, so committee-level filtering isn't available
+        # here — surface that instead of silently dropping it.
         endpoint = "/committee-meeting"
         if congress:
             endpoint = f"{endpoint}/{congress}"
             if chamber:
                 endpoint = f"{endpoint}/{chamber}"
-                if committee_code:
-                    endpoint = f"{endpoint}/{committee_code}"
-        
+        if committee_code:
+            logger.info(f"committee_code '{committee_code}' is not filterable on the committee-meeting search endpoint; ignoring")
+
         logger.debug(f"Searching committee meetings with endpoint: {endpoint}, params: {params}")
         data = await safe_congressional_request(endpoint, ctx, params, endpoint_type='committee-meetings')
         
@@ -425,6 +429,8 @@ async def search_committee_meetings(
         
         logger.info(f"Found {len(meetings)} committee meetings matching the search criteria")
         lines = ["Search Results - Committee Meetings:"]
+        if committee_code:
+            lines.append(f"(Note: committee-level filtering by '{committee_code}' is not supported by this endpoint; showing all {chamber or 'chamber'} meetings.)")
         for meeting_item in meetings:
             lines.append("")
             lines.append(format_committee_meeting_item(meeting_item))

--- a/congress_api/features/committees.py
+++ b/congress_api/features/committees.py
@@ -471,43 +471,51 @@ async def get_committee_communications(
             logger.warning(f"Invalid limit: {limit}")
             return limit_validation.error_message
         
-        # Build endpoint
-        endpoint = f"/committee/{chamber.lower()}/{committee_code}/communications"
-        
+        # Build endpoint. The committee communications sub-resource is chamber-
+        # specific: /committee/{chamber}/{code}/house-communication (House) or
+        # /senate-communication (Senate). There is no /communications path, and
+        # Joint committees have no communications resource.
+        chamber_l = chamber.lower()
+        if chamber_l == "house":
+            sub_resource, response_key = "house-communication", "houseCommunications"
+        elif chamber_l == "senate":
+            sub_resource, response_key = "senate-communication", "senateCommunications"
+        else:
+            return f"Committee communications are not available for {chamber.capitalize()} committees (House and Senate only)."
+
+        endpoint = f"/committee/{chamber_l}/{committee_code}/{sub_resource}"
+
         # Make API request
         response = await safe_committees_request(endpoint, ctx, {"limit": limit})
-        
+
         if "error" in response:
             logger.warning(f"API error for committee communications: {response['error']}")
             return response["error"]
-        
-        communications = response.get("communications", [])
+
+        communications = response.get(response_key, [])
         if not communications:
             return f"No communications found for committee {committee_code} in the {chamber.capitalize()}."
-        
+
         # Deduplicate communications
         communications = ResponseProcessor.deduplicate_results(
-            communications, 
+            communications,
             key_fields=["congress", "number"]
         )
-        
+
         # Format results
         result = [f"Communications for {chamber.capitalize()} Committee {committee_code}:"]
         for comm in communications[:limit]:
             number = comm.get("number", "Unknown")
             congress = comm.get("congress", "Unknown")
             url = comm.get("url", "No URL available")
-            
+
             # Get communication type
             comm_type = comm.get("communicationType", {})
-            type_name = comm_type.get("name", "Unknown")
-            
-            # Get committee referral info
-            committees = comm.get("committees", [])
-            referral_date = "Unknown"
-            if committees:
-                referral_date = committees[0].get("referralDate", "Unknown")
-            
+            type_name = comm_type.get("name", "Unknown") if isinstance(comm_type, dict) else "Unknown"
+
+            # referralDate is a top-level field on each communication
+            referral_date = comm.get("referralDate", "Unknown")
+
             result.append(f"\n**{type_name} {number}** (Congress {congress})")
             result.append(f"Referral Date: {referral_date}")
             result.append(f"URL: {url}")

--- a/congress_api/features/members.py
+++ b/congress_api/features/members.py
@@ -821,40 +821,48 @@ async def get_members_by_congress_state_district(
         if current_member:
             params["currentMember"] = "true"
         
-        # Determine endpoint based on whether district is provided
+        # Determine endpoint. When a district is given, use the dedicated
+        # congress-scoped endpoint /member/congress/{congress}/{state}/{district},
+        # which filters by congress server-side. The API has no congress+state-only
+        # endpoint, so the state-only case falls back to /member/{state} plus a
+        # client-side congress filter.
         if district is not None:
-            endpoint = f"/member/{state_code}/{district}"
+            endpoint = f"/member/congress/{congress}/{state_code}/{district}"
+            server_filtered_by_congress = True
         else:
             endpoint = f"/member/{state_code}"
-        
+            server_filtered_by_congress = False
+
         # Make the API request
         data = await safe_congressional_request(endpoint, ctx, params, endpoint_type='members')
-        
+
         if "error" in data:
             return format_error_response(CommonErrors.api_server_error(f"Error retrieving members: {data['error']}"))
-        
+
         members = data.get("members", [])
         if not members:
             district_str = f" district {district}" if district else ""
             return f"No members found for {state_code}{district_str} in Congress {congress}."
-        
-        # Filter by congress if the API doesn't handle it directly
-        filtered_members = []
-        for member in members:
-            # Check if member served in the specified congress
-            if "terms" in member:
-                terms = member["terms"]
-                # Handle case where terms might be wrapped in an object with 'item' key
-                if isinstance(terms, dict) and "item" in terms:
-                    terms = terms["item"]
-                
-                if terms and isinstance(terms, list):
-                    # Check if any term matches the specified congress
-                    for term in terms:
-                        if isinstance(term, dict) and term.get("congress") == congress:
-                            filtered_members.append(member)
-                            break
-        
+
+        if server_filtered_by_congress:
+            # The API already filtered by congress; no client-side term filtering.
+            filtered_members = members
+        else:
+            # Client-side congress filter via each member's terms (state-only path).
+            filtered_members = []
+            for member in members:
+                if "terms" in member:
+                    terms = member["terms"]
+                    # terms may be wrapped in an object with an 'item' key
+                    if isinstance(terms, dict) and "item" in terms:
+                        terms = terms["item"]
+
+                    if terms and isinstance(terms, list):
+                        for term in terms:
+                            if isinstance(term, dict) and term.get("congress") == congress:
+                                filtered_members.append(member)
+                                break
+
         # Process and deduplicate results
         filtered_members = response_processor.deduplicate_results(
             filtered_members, 

--- a/tests/test_endpoint_fixes.py
+++ b/tests/test_endpoint_fixes.py
@@ -1,0 +1,71 @@
+"""
+Mocked regression tests for the Batch-3 endpoint fixes — assert each impl builds
+the CORRECT endpoint path (the bugs were all wrong/non-existent paths).
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+class FakeContext:
+    pass
+
+
+def _endpoint_of(mock):
+    return mock.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_committee_communications_uses_house_communication_path():
+    from congress_api.features import committees
+    resp = {"houseCommunications": [{"number": 1, "congress": 119,
+            "communicationType": {"name": "Executive Communication"},
+            "referralDate": "2025-01-01", "url": "u"}]}
+    with patch.object(committees, "safe_committees_request", new=AsyncMock(return_value=resp)) as m:
+        out = await committees.get_committee_communications(FakeContext(), committee_code="hspw00",
+                                                            chamber="house", limit=5)
+    assert _endpoint_of(m) == "/committee/house/hspw00/house-communication"
+    assert "Executive Communication 1" in out
+    assert "Referral Date: 2025-01-01" in out
+
+
+@pytest.mark.asyncio
+async def test_committee_communications_uses_senate_communication_path():
+    from congress_api.features import committees
+    resp = {"senateCommunications": [{"number": 2, "congress": 119,
+            "communicationType": {"name": "Executive Communication"},
+            "referralDate": "2025-02-02", "url": "u"}]}
+    with patch.object(committees, "safe_committees_request", new=AsyncMock(return_value=resp)) as m:
+        out = await committees.get_committee_communications(FakeContext(), committee_code="ssga00",
+                                                            chamber="senate", limit=5)
+    assert _endpoint_of(m) == "/committee/senate/ssga00/senate-communication"
+    assert "Executive Communication 2" in out
+
+
+@pytest.mark.asyncio
+async def test_members_by_congress_state_district_uses_congress_path():
+    from congress_api.features import members
+    resp = {"members": [{"bioguideId": "M001177", "name": "McClintock, Tom",
+                         "state": "California", "district": 5, "partyName": "Republican"}]}
+    with patch.object(members, "safe_congressional_request", new=AsyncMock(return_value=resp)) as m:
+        out = await members.get_members_by_congress_state_district(FakeContext(), congress=119,
+                                                                   state_code="CA", district=5)
+    assert _endpoint_of(m) == "/member/congress/119/CA/5"
+    assert "McClintock" in out
+
+
+@pytest.mark.asyncio
+async def test_search_committee_meetings_drops_committee_code_segment():
+    from congress_api.features import committee_meetings
+    resp = {"committeeMeetings": [{"chamber": "House", "congress": 119,
+                                   "eventId": "119423", "url": "u"}]}
+    with patch.object(committee_meetings, "safe_congressional_request", new=AsyncMock(return_value=resp)) as m:
+        out = await committee_meetings.search_committee_meetings(FakeContext(), congress=119,
+                                                                 chamber="house", committee_code="hsag00", limit=5)
+    # committee_code must NOT appear as a path segment (the bug)
+    assert _endpoint_of(m) == "/committee-meeting/119/house"
+    assert "not supported" in out  # the explanatory note


### PR DESCRIPTION
Three tools called paths the current API rejects:
- get_committee_communications hit /committee/{chamber}/{code}/communications, which 404s. The real sub-resources are chamber-specific: .../house-communication and .../senate-communication (read the matching houseCommunications/senateCommunications key; referralDate is top-level).
- get_members_by_congress_state_district used /member/{state}/{district} plus a fragile client-side congress filter; the dedicated /member/congress/{congress}/{state}/{district} endpoint exists and is used now.
- search_committee_meetings appended the committee code as a 4th path segment, but that slot is {eventId}, so it 404'd; drop it (the meeting list carries no committee code, so committee filtering is surfaced as a note).

All three verified against the live API; adds endpoint-assertion tests.