### PR TITLE
feat: add laws tool for enacted public/private laws

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,15 @@ Sign up at **[api.congress.gov/sign-up](https://api.congress.gov/sign-up/)** (ta
 
 ## Tools
 
-**6 toolsets, 91+ operations** covering all Congress.gov API endpoints:
+**7 toolsets, 90+ operations** covering the Congress.gov API:
 
 | Toolset | Operations | What it does |
 |---------|-----------|--------------|
 | **Bills** | 16 | Search, details, text, actions, amendments, cosponsors, subjects |
+| **Laws** | 2 | Enacted public/private laws by congress (`get_laws`, `get_law_details`) |
 | **Amendments** | 7 | Search, details, actions, sponsors, text |
 | **Treaties & Summaries** | 5 | Treaty search, actions, committees, text; bill summaries |
-| **Members & Committees** | 13 | Member search by name/state/district, sponsored legislation, committee bills/reports |
+| **Members & Committees** | 13 | Member search by name/state/district, sponsored legislation, committee bills/reports/communications |
 | **Voting & Nominations** | 13 | House/Senate votes, nominations, roll calls |
 | **Records & Hearings** | 10+ | Congressional Record, hearings, CRS reports, committee prints |
 

--- a/congress_api/features/buckets/laws.py
+++ b/congress_api/features/buckets/laws.py
@@ -1,0 +1,168 @@
+"""
+Congressional Laws tool — enacted public and private laws via the /law endpoint.
+
+The /law endpoints return the same shapes as /bill (a `bills` list for listings,
+a `bill` object for details, each law carrying a `laws: [{number, type}]` field),
+so this tool reuses BillsFormatter directly.
+
+Operations:
+- get_laws: list enacted laws for a congress, optionally by law type (pub/priv).
+- get_law_details: detail for a specific law (congress + law type + law number).
+"""
+import logging
+from typing import Optional
+
+from mcp.server.fastmcp import Context
+from mcp.server.fastmcp.exceptions import ToolError
+
+from ...mcp_app import mcp
+from ...core.api_wrapper import safe_congressional_request
+from ...core.validators import ParameterValidator
+from .bills.formatters import BillsFormatter
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_law_type(law_type: Optional[str]) -> Optional[str]:
+    """Map friendly law-type aliases to the API's 'pub'/'priv'. None passes through."""
+    if not law_type:
+        return None
+    lt = law_type.strip().lower()
+    if lt in ("pub", "public"):
+        return "pub"
+    if lt in ("priv", "private"):
+        return "priv"
+    return None
+
+
+async def get_laws(
+    ctx: Context,
+    congress: int,
+    law_type: Optional[str] = None,
+    limit: int = 20,
+    offset: Optional[int] = None,
+) -> str:
+    """List enacted laws for a congress (optionally filtered by pub/priv)."""
+    if congress is None:
+        return "A congress number is required (e.g. 119)."
+    congress_validation = ParameterValidator.validate_congress_number(congress)
+    if not congress_validation.is_valid:
+        return congress_validation.error_message
+
+    endpoint = f"/law/{congress}"
+    if law_type is not None:
+        normalized = _normalize_law_type(law_type)
+        if not normalized:
+            return f"Invalid law_type '{law_type}'. Use 'pub' (public) or 'priv' (private)."
+        endpoint = f"/law/{congress}/{normalized}"
+
+    params = {"limit": limit}
+    if offset is not None:
+        params["offset"] = offset
+
+    data = await safe_congressional_request(endpoint, ctx, params, endpoint_type="bills")
+    if isinstance(data, dict) and "error" in data:
+        return str(data["error"])
+
+    return BillsFormatter.format_bills_list(data, f"Laws — {congress}th Congress")
+
+
+async def get_law_details(
+    ctx: Context,
+    congress: int,
+    law_type: str,
+    law_number: int,
+) -> str:
+    """Get detail for a specific enacted law."""
+    if congress is None or law_type is None or law_number is None:
+        return "get_law_details requires congress, law_type ('pub'/'priv'), and law_number."
+    congress_validation = ParameterValidator.validate_congress_number(congress)
+    if not congress_validation.is_valid:
+        return congress_validation.error_message
+
+    normalized = _normalize_law_type(law_type)
+    if not normalized:
+        return f"Invalid law_type '{law_type}'. Use 'pub' (public) or 'priv' (private)."
+
+    endpoint = f"/law/{congress}/{normalized}/{law_number}"
+    data = await safe_congressional_request(endpoint, ctx, {}, endpoint_type="bills")
+    if isinstance(data, dict) and "error" in data:
+        return str(data["error"])
+
+    bill = data.get("bill", {})
+    if not bill:
+        return f"No law found for {normalized} {law_number} in the {congress}th Congress."
+    return BillsFormatter.format_bill_detail(bill)
+
+
+async def route_laws_operation(ctx: Context, operation: str, **kwargs) -> str:
+    """Route a laws operation to its impl with only the params it accepts."""
+    if operation == "get_laws":
+        return await get_laws(
+            ctx,
+            congress=kwargs.get("congress"),
+            law_type=kwargs.get("law_type"),
+            limit=kwargs.get("limit") or 20,
+            offset=kwargs.get("offset"),
+        )
+    elif operation == "get_law_details":
+        return await get_law_details(
+            ctx,
+            congress=kwargs.get("congress"),
+            law_type=kwargs.get("law_type"),
+            law_number=kwargs.get("law_number"),
+        )
+    else:
+        raise ToolError(f"Unknown laws operation: {operation}")
+
+
+@mcp.tool(
+    "laws",
+    title="Congressional Laws - Enacted public and private laws",
+)
+async def laws(
+    ctx: Context,
+    operation: str,
+    congress: Optional[int] = None,
+    law_type: Optional[str] = None,
+    law_number: Optional[int] = None,
+    limit: Optional[int] = None,
+    offset: Optional[int] = None,
+) -> str:
+    """
+    Congressional Laws - enacted public and private laws (the /law endpoint).
+
+    OPERATIONS:
+    • get_laws: list enacted laws for a congress. Optional law_type ('pub' or
+      'priv') narrows to public or private laws.
+    • get_law_details: full detail for one law (needs congress, law_type, law_number).
+
+    Args:
+        operation: 'get_laws' or 'get_law_details'
+        congress: Congress number (e.g., 119) — required
+        law_type: 'pub' (public) or 'priv' (private); optional for get_laws,
+                  required for get_law_details
+        law_number: The law's sequential number (required for get_law_details)
+        limit: Max results for get_laws (default 20)
+        offset: Pagination offset for get_laws
+
+    Examples:
+        {"operation": "get_laws", "congress": 119}
+        {"operation": "get_laws", "congress": 119, "law_type": "pub", "limit": 10}
+        {"operation": "get_law_details", "congress": 119, "law_type": "pub", "law_number": 1}
+    """
+    try:
+        return await route_laws_operation(
+            ctx,
+            operation,
+            congress=congress,
+            law_type=law_type,
+            law_number=law_number,
+            limit=limit,
+            offset=offset,
+        )
+    except ToolError:
+        raise
+    except Exception as e:
+        logger.error(f"Error in laws tool ({operation}): {e}")
+        return f"Error executing laws operation '{operation}': {str(e)}"

--- a/congress_api/mcp_server.py
+++ b/congress_api/mcp_server.py
@@ -31,4 +31,5 @@ def initialize_mcp_features():
         records_and_hearings,
         committee_intelligence,
         research_and_professional,
+        laws,
     )

--- a/documentation/CongressAPI_documentation.md
+++ b/documentation/CongressAPI_documentation.md
@@ -705,6 +705,49 @@ GET /amendment/117/hamdt/287/text?api\_key=\[INSERT\_KEY\]
 
 ---
 
+## **Law API**
+
+Enacted laws. These endpoints return the same shapes as `/bill` (a `bills` list
+for listings, a `bill` object for detail); each law carries a
+`laws: [{ "number": "119-100", "type": "Public Law" }]` field. Exposed by the
+`laws` MCP tool (`get_laws`, `get_law_details`).
+
+### **GET `/law/{congress}`**
+
+Returns the list of laws (public and private) for the specified congress.
+
+```
+https://api.congress.gov/v3/law/119?api_key=[INSERT_KEY]
+```
+
+### **GET `/law/{congress}/{lawType}`**
+
+Returns laws filtered by type. `lawType` is `pub` (public) or `priv` (private).
+
+```
+https://api.congress.gov/v3/law/119/pub?api_key=[INSERT_KEY]
+```
+
+### **GET `/law/{congress}/{lawType}/{lawNumber}`**
+
+Returns detail for a specific law (response shape mirrors `/bill/.../{billNumber}`,
+top-level key `bill`).
+
+```
+https://api.congress.gov/v3/law/119/pub/1?api_key=[INSERT_KEY]
+```
+
+| Parameter | Description |
+| :---- | :---- |
+| congress * | The congress number. For example, 119. |
+| lawType | Law type — `pub` (public) or `priv` (private). |
+| lawNumber | The law's sequential number. For example, 1. |
+| format | The data format. Value can be xml or json. |
+| offset | The starting record returned. 0 is the first record. |
+| limit | The number of records returned. The maximum limit is 250. |
+
+---
+
 ## **Congress API**
 
 ### **GET `/congress`**

--- a/tests/test_laws_tool.py
+++ b/tests/test_laws_tool.py
@@ -1,0 +1,79 @@
+"""
+Mocked tests for the new `laws` tool: endpoint construction, law-type
+normalization, routing, and reuse of BillsFormatter.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from congress_api.features.buckets import laws
+
+
+class FakeContext:
+    pass
+
+
+_LIST = {"bills": [{"type": "S", "number": "1003", "congress": 119,
+                    "title": "Lulu's Law",
+                    "latestAction": {"text": "Became Public Law No: 119-100.",
+                                     "actionDate": "2026-06-26"},
+                    "laws": [{"number": "119-100", "type": "Public Law"}], "url": "u"}]}
+_DETAIL = {"bill": {"type": "S", "number": "5", "congress": 119,
+                    "title": "Laken Riley Act",
+                    "latestAction": {"text": "Became Public Law No: 119-1.", "actionDate": "2025-01-29"}}}
+
+
+def _endpoint(mock):
+    return mock.call_args.args[0]
+
+
+def test_normalize_law_type():
+    assert laws._normalize_law_type("public") == "pub"
+    assert laws._normalize_law_type("pub") == "pub"
+    assert laws._normalize_law_type("private") == "priv"
+    assert laws._normalize_law_type("priv") == "priv"
+    assert laws._normalize_law_type("xyz") is None
+    assert laws._normalize_law_type(None) is None
+
+
+@pytest.mark.asyncio
+async def test_get_laws_builds_congress_endpoint():
+    with patch.object(laws, "safe_congressional_request", new=AsyncMock(return_value=_LIST)) as m:
+        out = await laws.get_laws(FakeContext(), congress=119, limit=5)
+    assert _endpoint(m) == "/law/119"
+    assert "Lulu" in out and "119th Congress" in out
+
+
+@pytest.mark.asyncio
+async def test_get_laws_builds_lawtype_endpoint():
+    with patch.object(laws, "safe_congressional_request", new=AsyncMock(return_value=_LIST)) as m:
+        await laws.get_laws(FakeContext(), congress=119, law_type="public", limit=5)
+    assert _endpoint(m) == "/law/119/pub"
+
+
+@pytest.mark.asyncio
+async def test_get_laws_rejects_bad_lawtype():
+    with patch.object(laws, "safe_congressional_request", new=AsyncMock(return_value=_LIST)):
+        out = await laws.get_laws(FakeContext(), congress=119, law_type="bogus")
+    assert "Invalid law_type" in out
+
+
+@pytest.mark.asyncio
+async def test_get_law_details_builds_endpoint_and_formats():
+    with patch.object(laws, "safe_congressional_request", new=AsyncMock(return_value=_DETAIL)) as m:
+        out = await laws.get_law_details(FakeContext(), congress=119, law_type="pub", law_number=1)
+    assert _endpoint(m) == "/law/119/pub/1"
+    assert "Laken Riley Act" in out
+
+
+@pytest.mark.asyncio
+async def test_route_dispatches_operations():
+    with patch.object(laws, "safe_congressional_request", new=AsyncMock(return_value=_LIST)):
+        out = await laws.route_laws_operation(FakeContext(), "get_laws", congress=119)
+    assert "119th Congress" in out
+    with pytest.raises(Exception):
+        await laws.route_laws_operation(FakeContext(), "nonsense_op", congress=119)


### PR DESCRIPTION
Adds a `laws` MCP tool (get_laws / get_law_details) over the /law endpoints, which were previously unwrapped — there was no way to query enacted laws. /law returns the same shapes as /bill, so the tool reuses BillsFormatter. Registers the module in mcp_server, documents the Law API, and adds tests.