### PR TITLE
Add offset/most_recent paging to committee sub-resource tools - reverses to newest-first search

### DIFF
--- a/congress_api/features/committees.py
+++ b/congress_api/features/committees.py
@@ -19,6 +19,24 @@ async def safe_committees_request(endpoint: str, ctx: Context, params: Dict[str,
     """Safe API request wrapper for committees endpoints."""
     return await DefensiveAPIWrapper.safe_api_request(endpoint, ctx, params, endpoint_type="committees")
 
+async def _resolve_recent_offset(endpoint: str, ctx: Context, limit: int) -> tuple[int, Optional[int]]:
+    """Return (offset, total_count) for the LAST page of a committee sub-resource.
+
+    The committee bills/reports/communications/nominations endpoints return
+    oldest-first with no sort param, so the most recent items live at the end.
+    We probe ``pagination.count`` and compute the offset of the final page so a
+    caller can fetch newest items directly. Returns (0, None) if the count is
+    unavailable. ``pagination.count`` is present on all four endpoints.
+    """
+    probe = await safe_committees_request(endpoint, ctx, {"limit": 1})
+    if isinstance(probe, dict) and "error" not in probe:
+        count = (probe.get("pagination") or {}).get("count")
+        if isinstance(count, int) and count > limit:
+            return max(0, count - limit), count
+        if isinstance(count, int):
+            return 0, count
+    return 0, None
+
 # Formatting helpers
 def format_committee_summary(committee: Dict[str, Any]) -> str:
     """Format a committee into a readable summary."""
@@ -213,7 +231,9 @@ async def get_committee_bills(
     ctx: Context,
     committee_code: str,
     chamber: str | None = None,
-    limit: int = 10
+    limit: int = 10,
+    offset: Optional[int] = None,
+    most_recent: bool = True
 ) -> str:
     """
     Get bills referred to a specific committee.
@@ -223,6 +243,12 @@ async def get_committee_bills(
         chamber: The chamber of Congress ("house", "senate", or "joint").
                  If omitted, inferred from the committee code prefix.
         limit: Maximum number of bills to return (default: 10)
+        offset: Starting record (0-based). When set, paging is explicit and
+                most_recent is ignored.
+        most_recent: When True (default), return the newest referrals first.
+                     The endpoint is oldest-first with no sort, so this probes
+                     the total count and fetches the final page. Set False to
+                     get the oldest records (offset 0).
     """
     try:
         # Auto-derive chamber from committee code if not provided
@@ -245,26 +271,42 @@ async def get_committee_bills(
         
         # Build endpoint
         endpoint = f"/committee/{chamber.lower()}/{committee_code}/bills"
-        
+
+        # Resolve paging: explicit offset wins; else jump to the newest page.
+        total_count = None
+        if offset is None and most_recent:
+            offset, total_count = await _resolve_recent_offset(endpoint, ctx, limit)
+        params = {"limit": limit}
+        if offset:
+            params["offset"] = offset
+
         # Make API request
-        response = await safe_committees_request(endpoint, ctx, {"limit": limit})
-        
+        response = await safe_committees_request(endpoint, ctx, params)
+
         if "error" in response:
             logger.warning(f"API error for committee bills: {response['error']}")
             return response["error"]
-        
+
         bills = response.get("committee-bills", {}).get("bills", [])
         if not bills:
             return f"No bills found for committee {committee_code} in the {chamber.capitalize()}."
-        
+
+        # The endpoint is oldest-first; when showing the most-recent page, reverse
+        # so the newest referral is at the top.
+        if most_recent and offset:
+            bills = list(reversed(bills))
+
         # Deduplicate bills
         bills = ResponseProcessor.deduplicate_results(
-            bills, 
+            bills,
             key_fields=["congress", "number", "type"]
         )
-        
+
         # Format results
-        result = [f"Bills referred to {chamber.capitalize()} Committee {committee_code}:"]
+        header = f"Bills referred to {chamber.capitalize()} Committee {committee_code}"
+        if total_count is not None:
+            header += f" (showing {'newest ' if most_recent else ''}{min(limit, len(bills))} of {total_count} total)"
+        result = [header + ":"]
         for bill in bills[:limit]:
             bill_type = bill.get("type", "Unknown")
             number = bill.get("number", "Unknown")
@@ -290,7 +332,9 @@ async def get_committee_reports(
     ctx: Context,
     committee_code: str,
     chamber: str | None = None,
-    limit: int = 10
+    limit: int = 10,
+    offset: Optional[int] = None,
+    most_recent: bool = True
 ) -> str:
     """
     Get reports for a specific committee.
@@ -300,6 +344,10 @@ async def get_committee_reports(
         chamber: The chamber of Congress ("house", "senate", or "joint").
                  If omitted, inferred from the committee code prefix.
         limit: Maximum number of reports to return (default: 10)
+        offset: Starting record (0-based). When set, paging is explicit and
+                most_recent is ignored.
+        most_recent: When True (default), return the newest reports first
+                     (the endpoint is oldest-first with no sort).
     """
     try:
         # Auto-derive chamber from committee code if not provided
@@ -322,26 +370,40 @@ async def get_committee_reports(
         
         # Build endpoint
         endpoint = f"/committee/{chamber.lower()}/{committee_code}/reports"
-        
+
+        # Resolve paging: explicit offset wins; else jump to the newest page.
+        total_count = None
+        if offset is None and most_recent:
+            offset, total_count = await _resolve_recent_offset(endpoint, ctx, limit)
+        params = {"limit": limit}
+        if offset:
+            params["offset"] = offset
+
         # Make API request
-        response = await safe_committees_request(endpoint, ctx, {"limit": limit})
-        
+        response = await safe_committees_request(endpoint, ctx, params)
+
         if "error" in response:
             logger.warning(f"API error for committee reports: {response['error']}")
             return response["error"]
-        
+
         reports = response.get("reports", [])
         if not reports:
             return f"No reports found for committee {committee_code} in the {chamber.capitalize()}."
-        
+
+        if most_recent and offset:
+            reports = list(reversed(reports))
+
         # Deduplicate reports
         reports = ResponseProcessor.deduplicate_results(
-            reports, 
+            reports,
             key_fields=["congress", "number", "type"]
         )
-        
+
         # Format results
-        result = [f"Reports from {chamber.capitalize()} Committee {committee_code}:"]
+        header = f"Reports from {chamber.capitalize()} Committee {committee_code}"
+        if total_count is not None:
+            header += f" (showing {'newest ' if most_recent else ''}{min(limit, len(reports))} of {total_count} total)"
+        result = [header + ":"]
         for report in reports[:limit]:
             title = report.get("title", "No title available")
             report_type = report.get("type", "Unknown")
@@ -367,14 +429,20 @@ async def get_committee_reports(
 async def get_committee_nominations(
     ctx: Context,
     committee_code: str,
-    limit: int = 10
+    limit: int = 10,
+    offset: Optional[int] = None,
+    most_recent: bool = True
 ) -> str:
     """
     Get nominations for a specific Senate committee.
-    
+
     Args:
         committee_code: The committee code (e.g., "ssas00")
         limit: Maximum number of nominations to return (default: 10)
+        offset: Starting record (0-based) for explicit paging.
+        most_recent: Accepted for signature consistency with the other committee
+                     tools; the nominations endpoint is already newest-first, so
+                     the default page is the most recent.
     """
     try:
         # Validate parameters
@@ -382,29 +450,40 @@ async def get_committee_nominations(
         if not limit_validation.is_valid:
             logger.warning(f"Invalid limit: {limit}")
             return limit_validation.error_message
-        
-        # Build endpoint (nominations are Senate-only)
+
+        # Build endpoint (nominations are Senate-only). Unlike the bills/reports/
+        # communications sub-resources, the nominations endpoint is NEWEST-first,
+        # so most_recent is already the natural order — no jump-to-end needed.
         endpoint = f"/committee/senate/{committee_code}/nominations"
-        
+
+        params = {"limit": limit}
+        if offset:
+            params["offset"] = offset
+
         # Make API request
-        response = await safe_committees_request(endpoint, ctx, {"limit": limit})
-        
+        response = await safe_committees_request(endpoint, ctx, params)
+
         if "error" in response:
             logger.warning(f"API error for committee nominations: {response['error']}")
             return response["error"]
-        
+
         nominations = response.get("nominations", [])
         if not nominations:
             return f"No nominations found for Senate committee {committee_code}."
-        
+
+        total_count = (response.get("pagination") or {}).get("count")
+
         # Deduplicate nominations
         nominations = ResponseProcessor.deduplicate_results(
-            nominations, 
+            nominations,
             key_fields=["congress", "number"]
         )
-        
+
         # Format results
-        result = [f"Nominations for Senate Committee {committee_code}:"]
+        header = f"Nominations for Senate Committee {committee_code}"
+        if total_count is not None and offset is None:
+            header += f" (showing newest {min(limit, len(nominations))} of {total_count} total)"
+        result = [header + ":"]
         for nomination in nominations[:limit]:
             number = nomination.get("number", "Unknown")
             congress = nomination.get("congress", "Unknown")
@@ -441,7 +520,9 @@ async def get_committee_communications(
     ctx: Context,
     committee_code: str,
     chamber: str | None = None,
-    limit: int = 10
+    limit: int = 10,
+    offset: Optional[int] = None,
+    most_recent: bool = True
 ) -> str:
     """
     Get communications for a specific committee.
@@ -451,6 +532,10 @@ async def get_committee_communications(
         chamber: The chamber of Congress ("house", "senate", or "joint").
                  If omitted, inferred from the committee code prefix.
         limit: Maximum number of communications to return (default: 10)
+        offset: Starting record (0-based). When set, paging is explicit and
+                most_recent is ignored.
+        most_recent: When True (default), return the newest communications first
+                     (the endpoint is oldest-first with no sort).
     """
     try:
         # Auto-derive chamber from committee code if not provided
@@ -485,8 +570,16 @@ async def get_committee_communications(
 
         endpoint = f"/committee/{chamber_l}/{committee_code}/{sub_resource}"
 
+        # Resolve paging: explicit offset wins; else jump to the newest page.
+        total_count = None
+        if offset is None and most_recent:
+            offset, total_count = await _resolve_recent_offset(endpoint, ctx, limit)
+        params = {"limit": limit}
+        if offset:
+            params["offset"] = offset
+
         # Make API request
-        response = await safe_committees_request(endpoint, ctx, {"limit": limit})
+        response = await safe_committees_request(endpoint, ctx, params)
 
         if "error" in response:
             logger.warning(f"API error for committee communications: {response['error']}")
@@ -496,6 +589,9 @@ async def get_committee_communications(
         if not communications:
             return f"No communications found for committee {committee_code} in the {chamber.capitalize()}."
 
+        if most_recent and offset:
+            communications = list(reversed(communications))
+
         # Deduplicate communications
         communications = ResponseProcessor.deduplicate_results(
             communications,
@@ -503,7 +599,10 @@ async def get_committee_communications(
         )
 
         # Format results
-        result = [f"Communications for {chamber.capitalize()} Committee {committee_code}:"]
+        header = f"Communications for {chamber.capitalize()} Committee {committee_code}"
+        if total_count is not None:
+            header += f" (showing {'newest ' if most_recent else ''}{min(limit, len(communications))} of {total_count} total)"
+        result = [header + ":"]
         for comm in communications[:limit]:
             number = comm.get("number", "Unknown")
             congress = comm.get("congress", "Unknown")

--- a/congress_api/features/members_committees_tools.py
+++ b/congress_api/features/members_committees_tools.py
@@ -414,7 +414,9 @@ async def get_committee_bills(
     ctx: Context,
     committee_code: str,
     chamber: Optional[str] = None,
-    limit: int = 20
+    limit: int = 20,
+    offset: Optional[int] = None,
+    most_recent: bool = True
 ) -> MembersCommitteesResponse:
     """
     Get bills referred to or reported by a specific committee.
@@ -425,6 +427,9 @@ async def get_committee_bills(
         chamber: Chamber of Congress ("house", "senate", or "joint").
                  If omitted, inferred automatically from the committee code prefix.
         limit: Maximum number of bills to return
+        offset: Starting record (0-based) for explicit paging.
+        most_recent: When True (default), return the newest referrals first.
+                     The endpoint is oldest-first, so this fetches the final page.
 
     Returns:
         List of bills associated with the committee
@@ -435,7 +440,9 @@ async def get_committee_bills(
             ctx,
             committee_code=committee_code,
             chamber=chamber,
-            limit=limit
+            limit=limit,
+            offset=offset,
+            most_recent=most_recent
         )
         return convert_members_committees_response(raw_response, "get_committee_bills")
     except Exception as e:
@@ -458,7 +465,9 @@ async def get_committee_reports(
     ctx: Context,
     committee_code: str,
     chamber: Optional[str] = None,
-    limit: int = 20
+    limit: int = 20,
+    offset: Optional[int] = None,
+    most_recent: bool = True
 ) -> MembersCommitteesResponse:
     """
     Get reports issued by a specific committee.
@@ -469,6 +478,8 @@ async def get_committee_reports(
         chamber: Chamber of Congress ("house", "senate", or "joint").
                  If omitted, inferred automatically from the committee code prefix.
         limit: Maximum number of reports to return
+        offset: Starting record (0-based) for explicit paging.
+        most_recent: When True (default), return the newest reports first.
 
     Returns:
         List of reports issued by the committee
@@ -479,7 +490,9 @@ async def get_committee_reports(
             ctx,
             committee_code=committee_code,
             chamber=chamber,
-            limit=limit
+            limit=limit,
+            offset=offset,
+            most_recent=most_recent
         )
         return convert_members_committees_response(raw_response, "get_committee_reports")
     except Exception as e:
@@ -502,7 +515,9 @@ async def get_committee_communications(
     ctx: Context,
     committee_code: str,
     chamber: Optional[str] = None,
-    limit: int = 20
+    limit: int = 20,
+    offset: Optional[int] = None,
+    most_recent: bool = True
 ) -> MembersCommitteesResponse:
     """
     Get communications (letters, statements) from a specific committee.
@@ -513,6 +528,8 @@ async def get_committee_communications(
         chamber: Chamber of Congress ("house", "senate", or "joint").
                  If omitted, inferred automatically from the committee code prefix.
         limit: Maximum number of communications to return
+        offset: Starting record (0-based) for explicit paging.
+        most_recent: When True (default), return the newest communications first.
 
     Returns:
         List of communications from the committee
@@ -523,7 +540,9 @@ async def get_committee_communications(
             ctx,
             committee_code=committee_code,
             chamber=chamber,
-            limit=limit
+            limit=limit,
+            offset=offset,
+            most_recent=most_recent
         )
         return convert_members_committees_response(raw_response, "get_committee_communications")
     except Exception as e:
@@ -545,16 +564,20 @@ async def get_committee_communications(
 async def get_committee_nominations(
     ctx: Context,
     committee_code: str,
-    limit: int = 20
+    limit: int = 20,
+    offset: Optional[int] = None,
+    most_recent: bool = True
 ) -> MembersCommitteesResponse:
     """
     Get nominations referred to a specific committee.
-    
+
     Args:
         ctx: Context for API requests
         committee_code: Official committee code (e.g., 'HSJU', 'SSJU')
         limit: Maximum number of nominations to return
-    
+        offset: Starting record (0-based) for explicit paging.
+        most_recent: When True (default), return the newest nominations first.
+
     Returns:
         List of nominations referred to the committee
     """
@@ -563,7 +586,9 @@ async def get_committee_nominations(
         raw_response = await _get_committee_nominations(
             ctx,
             committee_code=committee_code,
-            limit=limit
+            limit=limit,
+            offset=offset,
+            most_recent=most_recent
         )
         return convert_members_committees_response(raw_response, "get_committee_nominations")
     except Exception as e:

--- a/tests/test_committee_paging.py
+++ b/tests/test_committee_paging.py
@@ -1,0 +1,104 @@
+"""
+Mocked tests for committee sub-resource paging (offset / most_recent).
+
+The committee bills/reports/communications endpoints are oldest-first with no
+sort, so most_recent must probe pagination.count and fetch the final page, then
+reverse for newest-first. The nominations endpoint is already newest-first, so it
+must NOT jump. These tests assert that behavior offline.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import patch
+
+from congress_api.features import committees
+
+
+class FakeContext:
+    pass
+
+
+# Oldest-first page: item "3" is newest. count says 100 total.
+_BILLS_PAGE = {
+    "committee-bills": {"bills": [
+        {"type": "S", "number": "1", "congress": 118, "actionDate": "2024-01-01"},
+        {"type": "S", "number": "2", "congress": 119, "actionDate": "2025-01-01"},
+        {"type": "S", "number": "3", "congress": 119, "actionDate": "2026-06-01"},
+    ]},
+    "pagination": {"count": 100},
+}
+
+
+def _bills_side_effect_factory(calls):
+    async def _se(endpoint, ctx, params=None):
+        calls.append(dict(params or {}))
+        return _BILLS_PAGE
+    return _se
+
+
+@pytest.mark.asyncio
+async def test_committee_bills_most_recent_jumps_and_reverses():
+    calls = []
+    with patch.object(committees, "safe_committees_request",
+                      new=_bills_side_effect_factory(calls)):
+        out = await committees.get_committee_bills(
+            FakeContext(), committee_code="sseg00", chamber="senate", limit=3)
+    # First call is the count probe (limit=1); the main fetch jumps to count-limit.
+    assert calls[0].get("limit") == 1
+    assert calls[-1].get("offset") == 97  # 100 - 3
+    # Output reversed -> newest (number 3) appears before oldest (number 1).
+    assert out.index("S 3") < out.index("S 1")
+    assert "of 100 total" in out
+
+
+@pytest.mark.asyncio
+async def test_committee_bills_oldest_no_jump():
+    calls = []
+    with patch.object(committees, "safe_committees_request",
+                      new=_bills_side_effect_factory(calls)):
+        out = await committees.get_committee_bills(
+            FakeContext(), committee_code="sseg00", chamber="senate", limit=3,
+            most_recent=False)
+    # No probe, no offset -> oldest order preserved (number 1 first).
+    assert all("offset" not in c for c in calls)
+    assert out.index("S 1") < out.index("S 3")
+
+
+@pytest.mark.asyncio
+async def test_committee_bills_explicit_offset_skips_probe():
+    calls = []
+    with patch.object(committees, "safe_committees_request",
+                      new=_bills_side_effect_factory(calls)):
+        await committees.get_committee_bills(
+            FakeContext(), committee_code="sseg00", chamber="senate", limit=3, offset=10)
+    # Explicit offset -> no count probe (no limit==1 call), uses the given offset.
+    assert all(c.get("limit") != 1 for c in calls)
+    assert calls[-1].get("offset") == 10
+
+
+@pytest.mark.asyncio
+async def test_committee_nominations_newest_first_no_jump():
+    calls = []
+    nominations_resp = {
+        "nominations": [
+            {"number": "1127", "congress": 119, "updateDate": "2026-06-25"},
+            {"number": "1000", "congress": 119, "updateDate": "2026-01-01"},
+        ],
+        "pagination": {"count": 5551},
+    }
+
+    async def _se(endpoint, ctx, params=None):
+        calls.append(dict(params or {}))
+        return nominations_resp
+
+    with patch.object(committees, "safe_committees_request", new=_se):
+        out = await committees.get_committee_nominations(
+            FakeContext(), committee_code="ssju00", limit=2)
+    # Newest-first endpoint: single fetch, no probe, no offset, order preserved.
+    assert len(calls) == 1
+    assert "offset" not in calls[0]
+    assert out.index("1127") < out.index("1000")
+    assert "of 5551 total" in out


### PR DESCRIPTION
get_committee_bills / reports / communications / nominations only fetches the first page, and the bills/reports/communications endpoints are oldest-first with no sort — so they surface decades-old records and could never reach recent (119th) referrals. 

Add `offset` and `most_recent` (default True): probe pagination.count and fetch the final page, reversed for newest-first, surfacing the total count. Nominations is already newest-first, so it skips the jump. Verified live across all four; adds mocked paging tests + a live regression.