### PR TITLE
Fix: bucket tools declared -> str but return a Pydantic response object

### DIFF
--- a/congress_api/features/buckets/committee_intelligence.py
+++ b/congress_api/features/buckets/committee_intelligence.py
@@ -210,7 +210,7 @@ async def committee_intelligence(
     offset: Optional[int] = None,
     from_date_time: Optional[str] = None,
     to_date_time: Optional[str] = None
-) -> str:
+) -> CommitteeIntelligenceResponse:
     """
     Congressional Committee Intelligence - Professional access to committee documents and activities.
 

--- a/congress_api/features/buckets/records_and_hearings.py
+++ b/congress_api/features/buckets/records_and_hearings.py
@@ -202,7 +202,7 @@ async def records_and_hearings(
     from_date_time: Optional[str] = None,
     to_date_time: Optional[str] = None,
     sort: Optional[str] = None
-) -> str:
+) -> RecordsHearingsResponse:
     """
     Congressional Records and Hearings - Access legislative records, communications, and hearings.
 

--- a/congress_api/features/buckets/research_and_professional.py
+++ b/congress_api/features/buckets/research_and_professional.py
@@ -148,7 +148,7 @@ async def research_and_professional(
     end_year: Optional[int] = None,
     # CRS report parameters
     report_number: Optional[str] = None
-) -> str:
+) -> ResearchProfessionalResponse:
     """
     Congressional Research and Professional - Access CRS reports and enhanced Congress analytics.
 

--- a/congress_api/features/buckets/voting_and_nominations.py
+++ b/congress_api/features/buckets/voting_and_nominations.py
@@ -181,7 +181,7 @@ async def voting_and_nominations(
     sort: Optional[str] = None,
     from_date: Optional[str] = None,
     to_date: Optional[str] = None
-) -> str:
+) -> VotingNominationsResponse:
     """
     Congressional Voting and Nominations - Access House votes and presidential nominations.
 

--- a/tests/test_bucket_double_conversion.py
+++ b/tests/test_bucket_double_conversion.py
@@ -109,3 +109,39 @@ def test_extract_result_count_handles_n_found_suffix():
 def test_extract_result_count_returns_zero_when_absent():
     from congress_api.utils.response_converters import _extract_result_count
     assert _extract_result_count("Search Results - Hearings:\n\nChamber: House") == 0
+
+
+# --- return-type annotation regression ---
+#
+# The double-conversion fix above made each top-level @mcp.tool function return
+# route_X_operation's result directly (already a Pydantic Response object), but
+# the function signatures were still declared "-> str" from the old
+# _convert_to_structured_response(...) call. FastMCP validates a tool's actual
+# return value against its declared return type to build/check the output
+# schema — a plain Python-level test (calling the function directly and reading
+# .summary/.results_count off the result) does NOT exercise that validation, so
+# this regression shipped once already and only surfaced through a real MCP
+# tool call. This test catches it statically, without needing a live server.
+
+import inspect
+
+
+@pytest.mark.parametrize("tool_name,module_path,expected_type_name", [
+    ("committee_intelligence", "congress_api.features.buckets.committee_intelligence", "CommitteeIntelligenceResponse"),
+    ("records_and_hearings", "congress_api.features.buckets.records_and_hearings", "RecordsHearingsResponse"),
+    ("research_and_professional", "congress_api.features.buckets.research_and_professional", "ResearchProfessionalResponse"),
+    ("voting_and_nominations", "congress_api.features.buckets.voting_and_nominations", "VotingNominationsResponse"),
+])
+def test_bucket_tool_return_annotation_matches_actual_return_type(tool_name, module_path, expected_type_name):
+    import importlib
+    mod = importlib.import_module(module_path)
+    tool_fn = getattr(mod, tool_name)
+    annotation = inspect.signature(tool_fn).return_annotation
+    assert annotation is not str, (
+        f"{tool_name} declares '-> str' but returns route_{tool_name}_operation's "
+        f"already-structured Pydantic response — FastMCP will reject the real "
+        f"output as invalid (str expected, Pydantic model given)."
+    )
+    assert getattr(annotation, "__name__", None) == expected_type_name, (
+        f"{tool_name}'s return annotation is {annotation!r}, expected {expected_type_name}"
+    )


### PR DESCRIPTION
Follow-up to f399aef. That fix made committee_intelligence, records_and_ hearings, research_and_professional, and voting_and_nominations return route_X_operation's result directly (already a fully-converted structured Response object), but their @mcp.tool function signatures were still declared "-> str" from the old _convert_to_structured_response(...) call they replaced.

FastMCP validates a tool's actual return value against its declared return type to build/enforce the output schema. Returning a Pydantic model where a plain string is expected fails that validation — confirmed live: every one of these 4 tools errored with "Input should be a valid string ... input_type=RecordsHearingsResponse" when called through the real deployed MCP server, immediately after reinstalling f399aef.

This slipped through mocked testing because calling these functions directly in Python (as the existing tests and my own manual verification both did) bypasses FastMCP's output-schema validation entirely — it only triggers on a real MCP tool invocation. Fix: declare the correct return type on each (CommitteeIntelligenceResponse / RecordsHearingsResponse / ResearchProfessionalResponse / VotingNominationsResponse), matching the already-correct pattern in members_committees_tools.py.

Adds a static regression test that checks each tool's declared return annotation against its actual return type without needing a live server or FastMCP internals — verified it fails against the pre-fix state and passes against the fix.