### PR TITLE
Migrate to MCP Python SDK v2

### DIFF
--- a/congress_api/__main__.py
+++ b/congress_api/__main__.py
@@ -6,7 +6,6 @@ Usage:
     uvx congressmcp                                     # stdio via uvx
 """
 import argparse
-import os
 import sys
 
 
@@ -22,9 +21,6 @@ def main():
     parser.add_argument("--port", type=int, default=8000, help="Port for HTTP transport (default: 8000)")
     args = parser.parse_args()
 
-    # Set transport before any server imports (mcp_server.py reads MCP_TRANSPORT at import time)
-    os.environ["MCP_TRANSPORT"] = args.transport
-
     # Import the server — main.py handles logging setup and feature initialization at import time
     from congress_api.main import server as mcp
 
@@ -32,7 +28,7 @@ def main():
         mcp.run()
     else:
         import uvicorn
-        app = mcp.streamable_http_app()
+        app = mcp.streamable_http_app(stateless_http=True)
         print(f"Starting Congress MCP server on {args.host}:{args.port}", file=sys.stderr)
         uvicorn.run(app, host=args.host, port=args.port)
 

--- a/congress_api/core/api_wrapper.py
+++ b/congress_api/core/api_wrapper.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from typing import Dict, Any, Optional
 from dataclasses import dataclass, replace
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from .client_handler import make_api_request
 from .exceptions import APIErrorResponse
 
@@ -49,7 +49,7 @@ class DefensiveAPIWrapper:
         return DefensiveAPIWrapper.ENDPOINT_CONFIGS['default']
     
     @staticmethod
-    async def safe_api_request(endpoint: str, ctx: Context, params: Optional[Dict[str, Any]] = None,
+    async def safe_api_request(endpoint: str, ctx: Optional[Context], params: Optional[Dict[str, Any]] = None,
                               timeout_override: Optional[float] = None, retry_count_override: Optional[int] = None,
                               endpoint_type: Optional[str] = None) -> Dict[str, Any]:
         if params is None: params = {}
@@ -89,6 +89,6 @@ class DefensiveAPIWrapper:
         elif "500" in error_str: return APIErrorResponse("server_error", "API issues.", ["Try later"], "SERVER_ERROR")
         else: return APIErrorResponse("api_failure", f"Failed after {retry_count + 1} attempts: {error}", ["Try later"], "GENERAL_API_FAILURE")
 
-async def safe_congressional_request(endpoint: str, ctx: Context, params: Optional[Dict[str, Any]] = None, endpoint_type: Optional[str] = None) -> Dict[str, Any]:
+async def safe_congressional_request(endpoint: str, ctx: Optional[Context], params: Optional[Dict[str, Any]] = None, endpoint_type: Optional[str] = None) -> Dict[str, Any]:
     """Generic convenience function for all Congressional API requests."""
     return await DefensiveAPIWrapper.safe_api_request(endpoint, ctx, params or {}, endpoint_type=endpoint_type)

--- a/congress_api/core/client_handler.py
+++ b/congress_api/core/client_handler.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from contextlib import asynccontextmanager
 from datetime import datetime
 
-from mcp.server.fastmcp import FastMCP, Context
+from mcp.server.mcpserver import MCPServer, Context
 from .api_config import API_KEY, BASE_URL, ENABLE_CACHING, CACHE_TIMEOUT, DEFAULT_REQUEST_PARAMS, ENV
 
 # Configure logger
@@ -65,19 +65,35 @@ class AppContext:
     request_count: int = 0
     start_time: datetime = field(default_factory=datetime.now)
 
+# MCP SDK v2 disallows Context injection on static (non-templated) resources,
+# so static resource handlers can't reach ctx.request_context.lifespan_context.
+# This module-level reference lets them reach the same AppContext directly.
+_current_app_context: Optional[AppContext] = None
+
+def get_app_context() -> AppContext:
+    """Access the running server's AppContext without a Context parameter.
+
+    For use by static resource handlers, which MCP SDK v2 does not permit
+    to declare a `ctx: Context` parameter.
+    """
+    if _current_app_context is None:
+        raise RuntimeError("Server not properly initialized - lifespan context unavailable")
+    return _current_app_context
+
 @asynccontextmanager
-async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
+async def app_lifespan(server: MCPServer) -> AsyncIterator[AppContext]:
     """Manage API client lifecycle with proper error handling and connection testing."""
+    global _current_app_context
     logger.info("Initializing Congress.gov API client...")
-    
+
     # Configure httpx client with timeouts and limits for production use
     timeout = httpx.Timeout(10.0, connect=5.0)  # 10s timeout, 5s connect timeout
     limits = httpx.Limits(max_keepalive_connections=5, max_connections=10)
-    
+
     try:
         async with httpx.AsyncClient(
-            base_url=BASE_URL, 
-            timeout=timeout, 
+            base_url=BASE_URL,
+            timeout=timeout,
             limits=limits,
             follow_redirects=True
         ) as client:
@@ -85,9 +101,10 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
                 logger.info("API key configured - skipping startup connection test")
             else:
                 logger.error("No API key provided. The server will start, but API requests will fail")
-            
+
             # Initialize and yield context to server
             context = AppContext(api_key=API_KEY or "MISSING_API_KEY", client=client)
+            _current_app_context = context
             logger.info("Server context initialized successfully")
             yield context
     except Exception as e:
@@ -95,6 +112,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
         # Re-raise to prevent server from starting with a broken client
         raise
     finally:
+        _current_app_context = None
         # Ensure clean shutdown even if there are errors
         try:
             logger.info("Cleaning up HTTP client resources...")
@@ -111,21 +129,29 @@ def generate_cache_key(endpoint: str, params: Dict[str, Any]) -> str:
     return f"{endpoint}?{param_str}"
 
 # Helper function for API requests
-async def make_api_request(endpoint: str, ctx: Context, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    """Make a request to the Congress.gov API with caching and proper error handling."""
+async def make_api_request(endpoint: str, ctx: Optional[Context] = None, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Make a request to the Congress.gov API with caching and proper error handling.
+
+    `ctx` is the request's MCP Context, used by tools and templated resources.
+    Static resource handlers can't declare a Context parameter under MCP SDK v2,
+    so they pass `ctx=None` and the AppContext is pulled from `get_app_context()` instead.
+    """
     start_time = time.time()
-    
+
     try:
         logger.debug(f"Starting make_api_request for endpoint: {endpoint}")
         # Access the lifespan context to get the HTTP client with error handling
-        try:
-            app_ctx = ctx.request_context.lifespan_context
-            if app_ctx is None:
-                raise ValueError("Lifespan context is None - server may not be fully initialized")
-        except AttributeError as e:
-            logger.error(f"Failed to access lifespan context: {e}")
-            raise RuntimeError("Server not properly initialized - lifespan context unavailable") from e
-        
+        if ctx is None:
+            app_ctx = get_app_context()
+        else:
+            try:
+                app_ctx = ctx.request_context.lifespan_context
+                if app_ctx is None:
+                    raise ValueError("Lifespan context is None - server may not be fully initialized")
+            except AttributeError as e:
+                logger.error(f"Failed to access lifespan context: {e}")
+                raise RuntimeError("Server not properly initialized - lifespan context unavailable") from e
+
         client = app_ctx.client
         api_key = app_ctx.api_key
         
@@ -163,7 +189,8 @@ async def make_api_request(endpoint: str, ctx: Context, params: Optional[Dict[st
         except json.JSONDecodeError:
             error_message = f"API returned non-JSON response for endpoint {endpoint}: {response.text[:100]}..."
             logger.error(error_message)
-            ctx.error(error_message)
+            if ctx is not None:
+                ctx.error(error_message)
             return {"error": error_message}
         
         # Cache the successful response if caching is enabled
@@ -191,9 +218,10 @@ async def make_api_request(endpoint: str, ctx: Context, params: Optional[Dict[st
             ctx_error_message += f" - {e.response.text[:100]}"
             if len(e.response.text) > 100:
                 ctx_error_message += "..."
-        
-        ctx.error(ctx_error_message)
-        
+
+        if ctx is not None:
+            ctx.error(ctx_error_message)
+
         # Return an error response with enough detail for clients
         # We'll keep the original error message but sanitize it for logging
         return {
@@ -212,9 +240,10 @@ async def make_api_request(endpoint: str, ctx: Context, params: Optional[Dict[st
         ctx_error_message = f"Request failed after {request_time:.2f}s"
         if ENV != "production":
             ctx_error_message += f": {str(e)}"
-        
-        ctx.error(ctx_error_message)
-        
+
+        if ctx is not None:
+            ctx.error(ctx_error_message)
+
         return {
             "error": "Network error during API request to Congress.gov API",
             "request_time": request_time
@@ -230,9 +259,10 @@ async def make_api_request(endpoint: str, ctx: Context, params: Optional[Dict[st
         ctx_error_message = f"An unexpected error occurred during API request after {request_time:.2f}s"
         if ENV != "production":
             ctx_error_message += f": {str(e)}"
-        
-        ctx.error(ctx_error_message)
-        
+
+        if ctx is not None:
+            ctx.error(ctx_error_message)
+
         return {
             "error": f"Unexpected error during API request to endpoint: {endpoint}",
             "request_time": request_time

--- a/congress_api/features/amendments_resources.py
+++ b/congress_api/features/amendments_resources.py
@@ -2,7 +2,7 @@
 from typing import Dict, Any
 import json
 import logging
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.api_wrapper import DefensiveAPIWrapper
 
@@ -29,7 +29,7 @@ def format_amendment_summary(amendment: Dict[str, Any]) -> str:
 
 # Resources
 @mcp.resource("congress://amendments/latest")
-async def get_latest_amendments(ctx: Context) -> str:
+async def get_latest_amendments() -> str:
     """
     Get the most recent amendments introduced in Congress.
 
@@ -38,7 +38,7 @@ async def get_latest_amendments(ctx: Context) -> str:
     """
     logger.info("Accessing latest amendments resource")
     try:
-        data = await DefensiveAPIWrapper.safe_api_request("/amendment", ctx, {"limit": 10, "sort": "updateDate+desc"}, timeout_override=10.0)
+        data = await DefensiveAPIWrapper.safe_api_request("/amendment", None, {"limit": 10, "sort": "updateDate+desc"}, timeout_override=10.0)
         logger.info(f"API response received: {data.keys() if isinstance(data, dict) else 'not a dict'}")
 
         if "error" in data:

--- a/congress_api/features/amendments_tool.py
+++ b/congress_api/features/amendments_tool.py
@@ -7,8 +7,8 @@ that handles all amendment-related operations through a clean, structured interf
 
 import logging
 from typing import Optional
-from mcp.server.fastmcp import Context
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context
+from mcp.server.mcpserver.exceptions import ToolError
 from ..mcp_app import mcp
 
 logger = logging.getLogger(__name__)

--- a/congress_api/features/bills_resources.py
+++ b/congress_api/features/bills_resources.py
@@ -6,13 +6,12 @@ including bill types, Congress ranges, status definitions, and usage guides.
 All operational bill functions have been moved to the bills/ module.
 """
 
-from mcp.server.fastmcp import Context
 from ..mcp_app import mcp
 
 # --- MCP Resources ---
 
 @mcp.resource("congress://bills/types")
-async def get_bill_types_reference(ctx: Context) -> str:
+async def get_bill_types_reference() -> str:
     """
     Get reference information about Congressional bill types.
     
@@ -94,7 +93,7 @@ When using the Bills API tools, specify bill types using these exact codes:
 """
 
 @mcp.resource("congress://bills/congress-ranges")
-async def get_congress_ranges_reference(ctx: Context) -> str:
+async def get_congress_ranges_reference() -> str:
     """
     Get reference information about Congress number ranges and coverage.
     
@@ -164,7 +163,7 @@ async def get_congress_ranges_reference(ctx: Context) -> str:
 """
 
 @mcp.resource("congress://bills/status-definitions")
-async def get_bill_status_definitions(ctx: Context) -> str:
+async def get_bill_status_definitions() -> str:
     """
     Get reference definitions for bill statuses and legislative process stages.
     
@@ -281,7 +280,7 @@ async def get_bill_status_definitions(ctx: Context) -> str:
 """
 
 @mcp.resource("congress://bills/usage-guide")
-async def get_bills_api_usage_guide(ctx: Context) -> str:
+async def get_bills_api_usage_guide() -> str:
     """
     Get usage guidelines and best practices for the Bills API.
     

--- a/congress_api/features/bills_tool.py
+++ b/congress_api/features/bills_tool.py
@@ -7,8 +7,8 @@ that handles all bill-related operations through a clean, structured interface.
 
 import logging
 from typing import Optional
-from mcp.server.fastmcp import Context
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context
+from mcp.server.mcpserver.exceptions import ToolError
 from ..mcp_app import mcp
 from ..utils.bill_parser import parse_bill_reference, validate_bill_params
 

--- a/congress_api/features/bound_congressional_record.py
+++ b/congress_api/features/bound_congressional_record.py
@@ -7,7 +7,7 @@ search functionality and individual record retrieval.
 
 import logging
 from typing import Optional, Dict, Any
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 from ..core.client_handler import make_api_request
 from ..core.validators import BoundCongressionalRecordValidator, ParameterValidator
@@ -87,7 +87,7 @@ def format_bound_record_detail(record_data: Dict[str, Any]) -> str:
 
 # @require_paid_access
 @mcp.resource("congress://bound-congressional-record/latest")
-async def get_latest_bound_congressional_record(ctx: Context) -> str:
+async def get_latest_bound_congressional_record() -> str:
     """
     Get the most recent bound congressional record issues.
     Returns the 10 most recently published issues by default.
@@ -96,9 +96,9 @@ async def get_latest_bound_congressional_record(ctx: Context) -> str:
         "limit": 10,
         "format": "json"
     }
-    
+
     logger.debug("Fetching latest bound congressional record issues")
-    data = await make_api_request("/bound-congressional-record", ctx, params=params)
+    data = await make_api_request("/bound-congressional-record", ctx=None, params=params)
     
     if "error" in data:
         logger.error(f"Error retrieving latest bound congressional record issues: {data['error']}")

--- a/congress_api/features/buckets/amendments/api.py
+++ b/congress_api/features/buckets/amendments/api.py
@@ -7,7 +7,7 @@ helpers, processors, and formatters to create API-faithful functions.
 
 import logging
 from typing import Optional
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from .processors import AmendmentsDataProcessor
 from .formatters import AmendmentsFormatter
 from ....core.validators import ParameterValidator

--- a/congress_api/features/buckets/bills/api.py
+++ b/congress_api/features/buckets/bills/api.py
@@ -7,7 +7,7 @@ to Congress.gov endpoints while maintaining enhancement capabilities.
 
 from typing import Optional
 import logging
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 # Import our modular components
 from .helpers import fetch_bill_data, build_bill_endpoint, validate_api_parameters

--- a/congress_api/features/buckets/bills/helpers.py
+++ b/congress_api/features/buckets/bills/helpers.py
@@ -7,7 +7,7 @@ without any business logic or formatting concerns.
 
 from typing import Dict, Optional, Any
 import logging
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 
 # Import existing validation and API infrastructure
 from ....core.validators import ParameterValidator

--- a/congress_api/features/buckets/committee_intelligence.py
+++ b/congress_api/features/buckets/committee_intelligence.py
@@ -7,8 +7,8 @@ All operations are available to all users.
 
 import logging
 from typing import Optional
-from mcp.server.fastmcp import Context
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context
+from mcp.server.mcpserver.exceptions import ToolError
 from ...mcp_app import mcp
 from ...models.responses import CommitteeIntelligenceResponse, CommitteeActivitySummary
 from ...utils.response_converters import _extract_result_count

--- a/congress_api/features/buckets/laws.py
+++ b/congress_api/features/buckets/laws.py
@@ -12,8 +12,8 @@ Operations:
 import logging
 from typing import Optional
 
-from mcp.server.fastmcp import Context
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context
+from mcp.server.mcpserver.exceptions import ToolError
 
 from ...mcp_app import mcp
 from ...core.api_wrapper import safe_congressional_request

--- a/congress_api/features/buckets/records_and_hearings.py
+++ b/congress_api/features/buckets/records_and_hearings.py
@@ -7,8 +7,8 @@ All operations are available to all users.
 
 import logging
 from typing import Optional
-from mcp.server.fastmcp import Context
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context
+from mcp.server.mcpserver.exceptions import ToolError
 from ...mcp_app import mcp
 from ...models.responses import RecordsHearingsResponse, HearingSummary, RecordSummary
 from ...utils.response_converters import _extract_result_count

--- a/congress_api/features/buckets/research_and_professional.py
+++ b/congress_api/features/buckets/research_and_professional.py
@@ -7,8 +7,8 @@ All operations are available to all users.
 
 import logging
 from typing import Optional
-from mcp.server.fastmcp import Context
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context
+from mcp.server.mcpserver.exceptions import ToolError
 from ...mcp_app import mcp
 from ...models.responses import ResearchProfessionalResponse, ResearchSummary
 from ...utils.response_converters import _extract_result_count

--- a/congress_api/features/buckets/voting_and_nominations.py
+++ b/congress_api/features/buckets/voting_and_nominations.py
@@ -7,8 +7,8 @@ All operations are available to all users.
 
 import logging
 from typing import Optional
-from mcp.server.fastmcp import Context
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context
+from mcp.server.mcpserver.exceptions import ToolError
 from ...mcp_app import mcp
 from ...models.responses import VotingNominationsResponse, VoteSummary, NominationSummary
 from ...utils.response_converters import _extract_result_count

--- a/congress_api/features/committee_meetings.py
+++ b/congress_api/features/committee_meetings.py
@@ -1,7 +1,7 @@
 # congress_api/features/committee_meetings.py
 import logging
 from typing import Dict, Any, Optional
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator

--- a/congress_api/features/committee_prints.py
+++ b/congress_api/features/committee_prints.py
@@ -1,7 +1,7 @@
 # congress_api/features/committee_prints.py
 import logging
 from typing import Dict, List, Any, Optional
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.api_wrapper import safe_congressional_request

--- a/congress_api/features/committee_reports.py
+++ b/congress_api/features/committee_reports.py
@@ -3,7 +3,7 @@ import logging
 import re
 from typing import Dict, Any, Optional
 import httpx
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..core.client_handler import make_api_request
 from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator

--- a/congress_api/features/committees.py
+++ b/congress_api/features/committees.py
@@ -1,7 +1,7 @@
 # committees.py
 from typing import Dict, List, Any, Optional
 import logging
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator, ValidationResult
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 # Initialize defensive API wrapper
 defensive_api = DefensiveAPIWrapper()
 
-async def safe_committees_request(endpoint: str, ctx: Context, params: Dict[str, Any] = {}) -> Dict[str, Any]:
+async def safe_committees_request(endpoint: str, ctx: Optional[Context], params: Dict[str, Any] = {}) -> Dict[str, Any]:
     """Safe API request wrapper for committees endpoints."""
     return await DefensiveAPIWrapper.safe_api_request(endpoint, ctx, params, endpoint_type="committees")
 
@@ -53,14 +53,14 @@ def format_committee_summary(committee: Dict[str, Any]) -> str:
 # - get_committee_details: Specific committee details
 
 @mcp.resource("congress://committees")
-async def get_committees(ctx: Context) -> str:
+async def get_committees() -> str:
     """
     Get a list of congressional committees.
-    
+
     Returns a comprehensive list of committees in the House and Senate,
     including their names, chambers, and system codes.
     """
-    data = await make_api_request("/committee", ctx)
+    data = await make_api_request("/committee", ctx=None)
     
     if "error" in data:
         return f"Error retrieving committees: {data['error']}"

--- a/congress_api/features/congress_info.py
+++ b/congress_api/features/congress_info.py
@@ -3,7 +3,7 @@ from typing import Dict, Any, List, Optional, Union
 import json
 import logging
 import datetime
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator
@@ -15,7 +15,7 @@ from ..core.response_utils import ResponseProcessor
 logger = logging.getLogger(__name__)
 
 # Defensive API wrapper for Congress Info requests
-async def safe_congress_request(endpoint: str, ctx: Context, params: Dict[str, Any] = None) -> Dict[str, Any]:
+async def safe_congress_request(endpoint: str, ctx: Optional[Context], params: Dict[str, Any] = None) -> Dict[str, Any]:
     """
     Defensive wrapper for Congress Info API requests with:
     - Parameter sanitization
@@ -181,16 +181,16 @@ def handle_api_error(data: Dict[str, Any], error_message: str) -> str:
 
 # Resources (Static/Reference Data Only)
 @mcp.resource("congress://all")
-async def get_all_congresses(ctx: Context) -> str:
+async def get_all_congresses() -> str:
     """
     Get a list of all congresses.
-    
+
     Returns a list of all congresses with basic information about each,
     including session dates and chamber information.
     """
     logger.info("Accessing all congresses resource")
     try:
-        data = await safe_congress_request("/congress", ctx, {"limit": 20})
+        data = await safe_congress_request("/congress", ctx=None, params={"limit": 20})
         logger.info(f"API response received: {data.keys() if isinstance(data, dict) else 'not a dict'}")
         
         if "error" in data:

--- a/congress_api/features/congressional_record.py
+++ b/congress_api/features/congressional_record.py
@@ -3,7 +3,7 @@ import json
 import logging
 from typing import Dict, Any, List, Optional
 from datetime import datetime
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 # Defensive API wrapper for Congressional Record endpoints
-async def safe_congressional_record_request(endpoint: str, ctx: Context, params: Dict[str, Any] = None) -> Dict[str, Any]:
+async def safe_congressional_record_request(endpoint: str, ctx: Optional[Context], params: Dict[str, Any] = None) -> Dict[str, Any]:
     """
     Makes a defensive API request to Congressional Record endpoints with timeout handling,
     retry logic, and standardized error responses.
@@ -118,7 +118,7 @@ def format_record_detail(record_data: Dict[str, Any]) -> str:
 
 # @require_paid_access
 @mcp.resource("congress://congressional-record/latest")
-async def get_latest_congressional_record(ctx: Context) -> str:
+async def get_latest_congressional_record() -> str:
     """
     Get the most recent congressional record issues.
     Returns the 10 most recently published issues by default.
@@ -129,8 +129,8 @@ async def get_latest_congressional_record(ctx: Context) -> str:
             "limit": 10,
             "format": "json"
         }
-        
-        data = await safe_congressional_record_request("/congressional-record", ctx, params=params)
+
+        data = await safe_congressional_record_request("/congressional-record", ctx=None, params=params)
         logger.info(f"API response received: {data.keys() if isinstance(data, dict) else 'not a dict'}")
         
         if "error" in data:

--- a/congress_api/features/crs_reports.py
+++ b/congress_api/features/crs_reports.py
@@ -1,7 +1,7 @@
 # congress_api/features/crs_reports.py
 import logging
 from typing import Dict, List, Any, Optional
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator
@@ -15,14 +15,14 @@ logger.setLevel(logging.DEBUG)
 
 # --- Defensive API Wrapper ---
 
-async def safe_crs_reports_request(endpoint: str, params: Dict[str, Any], ctx: Context) -> Dict[str, Any]:
+async def safe_crs_reports_request(endpoint: str, params: Dict[str, Any], ctx: Optional[Context]) -> Dict[str, Any]:
     """
     Safe API request wrapper for CRS Reports with timeout and retry logic.
     
     Args:
         endpoint: API endpoint to call
         params: Parameters for the API request
-        ctx: FastMCP context
+        ctx: MCP server context
         
     Returns:
         API response data
@@ -149,25 +149,25 @@ def format_crs_reports_list(data: Dict[str, Any]) -> str:
 
 # @require_paid_access
 @mcp.resource("congress://crs-reports/latest")
-async def get_latest_crs_reports(ctx: Context) -> str:
+async def get_latest_crs_reports() -> str:
     """
     Get the most recent CRS reports.
     Returns the 10 most recently published reports by default.
     """
     try:
         logger.debug("Getting latest CRS reports")
-        
+
         # Set up parameters for the API request
         params = {
             'format': 'json',
             'limit': 10
         }
-        
+
         # Make the API request
         data = await safe_crs_reports_request(
             endpoint="/crsreport",
             params=params,
-            ctx=ctx
+            ctx=None
         )
         
         # Check if there was an error in the response

--- a/congress_api/features/daily_congressional_record.py
+++ b/congress_api/features/daily_congressional_record.py
@@ -1,7 +1,7 @@
 # congress_api/features/daily_congressional_record.py
 import logging
 from typing import Dict, List, Any, Optional
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator
@@ -15,14 +15,14 @@ logger.setLevel(logging.DEBUG)
 
 # --- Defensive API Wrapper ---
 
-async def safe_daily_congressional_record_request(endpoint: str, params: Dict[str, Any], ctx: Context) -> Dict[str, Any]:
+async def safe_daily_congressional_record_request(endpoint: str, params: Dict[str, Any], ctx: Optional[Context]) -> Dict[str, Any]:
     """
     Safe API request wrapper for Daily Congressional Record with timeout and retry logic.
     
     Args:
         endpoint: API endpoint to call
         params: Parameters for the API request
-        ctx: FastMCP context
+        ctx: MCP server context
         
     Returns:
         API response data
@@ -128,7 +128,7 @@ def format_daily_record_articles(articles_data: Dict[str, Any]) -> str:
 
 # @require_paid_access
 @mcp.resource("congress://daily-congressional-record/latest")
-async def get_latest_daily_congressional_record(ctx: Context) -> str:
+async def get_latest_daily_congressional_record() -> str:
     """
     Get the most recent daily congressional record issues.
     Returns the 10 most recently published issues by default.
@@ -140,7 +140,7 @@ async def get_latest_daily_congressional_record(ctx: Context) -> str:
         data = await safe_daily_congressional_record_request(
             endpoint="/daily-congressional-record",
             params={"limit": 10},
-            ctx=ctx
+            ctx=None
         )
         
         # Check for error response from API

--- a/congress_api/features/hearings.py
+++ b/congress_api/features/hearings.py
@@ -1,7 +1,7 @@
 # congress_api/features/hearings.py
 import logging
 from typing import Dict, List, Any, Optional
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator, ValidationResult
@@ -67,7 +67,7 @@ def format_hearing_detail(hearing_item: Dict[str, Any]) -> str:
 
 # --- Defensive API Wrapper ---
 
-async def safe_hearings_request(endpoint: str, params: Dict[str, Any], ctx: Context) -> Dict[str, Any]:
+async def safe_hearings_request(endpoint: str, params: Dict[str, Any], ctx: Optional[Context]) -> Dict[str, Any]:
     """
     Safe API request wrapper for hearings endpoints with retry logic and error handling.
     
@@ -88,7 +88,7 @@ async def safe_hearings_request(endpoint: str, params: Dict[str, Any], ctx: Cont
 
 # --- Helper Functions ---
 
-async def get_latest_hearings(ctx: Context) -> str:
+async def get_latest_hearings(ctx: Optional[Context] = None) -> str:
     """
     Get a list of the most recent hearings.
     Returns the 10 most recently updated hearings by default.
@@ -166,9 +166,9 @@ class HearingsProcessor:
 
 # @require_paid_access
 @mcp.resource("congress://hearings/latest")
-async def latest_hearings_resource(ctx: Context) -> str:
+async def latest_hearings_resource() -> str:
     """Static resource providing the latest hearings."""
-    return await get_latest_hearings(ctx)
+    return await get_latest_hearings()
 
 # --- MCP Tools ---
 

--- a/congress_api/features/house_communications.py
+++ b/congress_api/features/house_communications.py
@@ -1,7 +1,7 @@
 # congress_api/features/house_communications.py
 import logging
 from typing import Dict, List, Any, Optional
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 
@@ -18,7 +18,7 @@ logger.setLevel(logging.DEBUG)
 # Initialize defensive API wrapper for house communications
 defensive_wrapper = DefensiveAPIWrapper()
 
-async def safe_house_communications_request(endpoint: str, params: Dict[str, Any], ctx: Context) -> Dict[str, Any]:
+async def safe_house_communications_request(endpoint: str, params: Dict[str, Any], ctx: Optional[Context]) -> Dict[str, Any]:
     """Make a safe API request for house communications with defensive wrapper."""
     return await defensive_wrapper.safe_api_request(
         endpoint=endpoint,
@@ -142,7 +142,7 @@ def format_house_communication_detail(comm_data: Dict[str, Any]) -> str:
 
 # --- Helper Functions ---
 
-async def get_latest_house_communications(ctx: Context, limit: int = 10) -> List[Dict[str, Any]]:
+async def get_latest_house_communications(ctx: Optional[Context] = None, limit: int = 10) -> List[Dict[str, Any]]:
     """Helper function to get latest house communications."""
     try:
         params = {
@@ -181,10 +181,10 @@ async def get_latest_house_communications(ctx: Context, limit: int = 10) -> List
 
 # @require_paid_access
 @mcp.resource("congress://house-communications/latest")
-async def latest_house_communications_resource(ctx: Context) -> str:
+async def latest_house_communications_resource() -> str:
     """Static resource providing the 10 most recent house communications."""
     try:
-        communications = await get_latest_house_communications(ctx, limit=10)
+        communications = await get_latest_house_communications(limit=10)
         
         if not communications:
             return "No recent house communications available."

--- a/congress_api/features/house_requirements.py
+++ b/congress_api/features/house_requirements.py
@@ -2,7 +2,7 @@
 
 import logging
 from typing import Dict, List, Any, Optional
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator
@@ -48,7 +48,7 @@ class HouseRequirementsProcessor(ResponseProcessor):
 
 # --- API Wrapper ---
 
-async def safe_house_requirements_request(endpoint: str, params: Dict[str, Any], ctx: Context) -> Dict[str, Any]:
+async def safe_house_requirements_request(endpoint: str, params: Dict[str, Any], ctx: Optional[Context]) -> Dict[str, Any]:
     """Safe API request wrapper for house requirements endpoints."""
     return await DefensiveAPIWrapper.safe_api_request(
         endpoint=endpoint,
@@ -154,7 +154,7 @@ def format_matching_communications(comms_data: Dict[str, Any]) -> str:
 
 # @require_paid_access
 @mcp.resource("congress://house-requirements/latest")
-async def get_latest_house_requirements(ctx: Context) -> str:
+async def get_latest_house_requirements() -> str:
     """
     Get the most recent house requirements.
     Returns the 10 most recently updated requirements by default.
@@ -164,11 +164,11 @@ async def get_latest_house_requirements(ctx: Context) -> str:
             "format": "json",
             "limit": 10
         }
-        
+
         logger.debug("Fetching latest house requirements")
-        
+
         # Make the API request
-        data = await safe_house_requirements_request("/house-requirement", params, ctx)
+        data = await safe_house_requirements_request("/house-requirement", params, ctx=None)
         
         if "error" in data:
             logger.error(f"Error fetching latest house requirements: {data['error']}")

--- a/congress_api/features/house_votes.py
+++ b/congress_api/features/house_votes.py
@@ -5,7 +5,7 @@ Handles fetching and processing House of Representatives roll call vote data fro
 from typing import Dict, List, Any, Optional
 import logging
 import json
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator, ValidationResult
@@ -349,16 +349,16 @@ def format_house_vote_xml_content(xml_content: str, source_url: str) -> str:
 
 # @require_paid_access
 @mcp.resource("congress://house-votes/latest")
-async def get_latest_house_votes(ctx: Context) -> str:
+async def get_latest_house_votes() -> str:
     """Get the latest House of Representatives roll call votes."""
     try:
         endpoint = "house-vote"
         params = {"format": "json", "limit": 10, "sort": "updateDate+desc"}
-        
+
         logger.debug("Fetching latest house votes")
-        
+
         # Make the API request
-        data = await safe_congressional_request(endpoint, ctx, params, endpoint_type='house-votes')
+        data = await safe_congressional_request(endpoint, None, params, endpoint_type='house-votes')
         
         if "error" in data:
             logger.error(f"Error fetching latest house votes: {data['error']}")

--- a/congress_api/features/members.py
+++ b/congress_api/features/members.py
@@ -1,6 +1,6 @@
 # members.py
 from typing import Dict, Any, Optional
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper, safe_congressional_request
@@ -17,14 +17,14 @@ response_processor = ResponseProcessor()
 
 # Resources (Static data only - no user parameters)
 @mcp.resource("congress://members/current")
-async def get_current_members(ctx: Context) -> str:
+async def get_current_members() -> str:
     """
     Get a list of current members of Congress.
-    
+
     Returns a sample of 20 current members from both chambers of Congress,
     including their biographical information and contact details.
     """
-    data = await safe_congressional_request("/member", ctx, {"limit": 20, "currentMember": "true"}, endpoint_type='members')
+    data = await safe_congressional_request("/member", None, {"limit": 20, "currentMember": "true"}, endpoint_type='members')
     
     if "error" in data:
         return f"Error retrieving members: {data['error']}"
@@ -40,14 +40,14 @@ async def get_current_members(ctx: Context) -> str:
     return "\n".join(result)
 
 @mcp.resource("congress://members/all")
-async def get_all_members(ctx: Context) -> str:
+async def get_all_members() -> str:
     """
     Get a list of congressional members.
-    
+
     Returns a list of congressional members with basic information about each,
     including their biographical information and contact details.
     """
-    data = await safe_congressional_request("/member", ctx, {"limit": 20}, endpoint_type='members')
+    data = await safe_congressional_request("/member", None, {"limit": 20}, endpoint_type='members')
     
     if "error" in data:
         return f"Error retrieving members: {data['error']}"

--- a/congress_api/features/members_committees_tools.py
+++ b/congress_api/features/members_committees_tools.py
@@ -7,7 +7,7 @@ structured Pydantic responses, and clear documentation.
 
 import logging
 from typing import Optional
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..models.responses import MembersCommitteesResponse
 from ..utils.response_converters import convert_members_committees_response

--- a/congress_api/features/nominations.py
+++ b/congress_api/features/nominations.py
@@ -6,7 +6,7 @@ This module provides access to nomination data from the Congress.gov API.
 
 import logging
 from typing import Dict, Any, List, Optional
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator

--- a/congress_api/features/senate_communications.py
+++ b/congress_api/features/senate_communications.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Dict, List, Any, Optional
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator
@@ -108,7 +108,7 @@ def format_senate_communications_list(communications: List[Dict[str, Any]], titl
 
 # @require_paid_access
 @mcp.resource("congress://senate-communications/latest")
-async def get_latest_senate_communications(ctx: Context) -> str:
+async def get_latest_senate_communications() -> str:
     """
     Get the most recent senate communications.
     Returns the 10 most recently published communications by default.
@@ -118,9 +118,9 @@ async def get_latest_senate_communications(ctx: Context) -> str:
             "limit": 10,
             "format": "json"
         }
-        
+
         logger.debug("Fetching latest senate communications")
-        data = await safe_congressional_request("/senate-communication", ctx, params, endpoint_type='senate_communications')
+        data = await safe_congressional_request("/senate-communication", None, params, endpoint_type='senate_communications')
         
         # Process response using reliability framework
         processed_communications = clean_senate_communications_response(data, limit=10)

--- a/congress_api/features/summaries.py
+++ b/congress_api/features/summaries.py
@@ -2,7 +2,7 @@
 from typing import Dict, Any, Optional, List
 import json
 import logging
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 
@@ -91,17 +91,17 @@ def format_summaries_list(summaries: List[Dict[str, Any]], title: str) -> str:
 
 # Resources
 @mcp.resource("congress://summaries/latest")
-async def get_latest_summaries(ctx: Context) -> str:
+async def get_latest_summaries() -> str:
     """
     Get the most recent bill summaries.
-    
+
     Returns a list of the 10 most recently updated summaries across all
     Congresses, sorted by update date in descending order.
     """
     logger.info("Accessing latest summaries resource")
     try:
         # Use defensive API wrapper
-        data = await safe_congressional_request("/summaries", ctx, {"limit": 10, "sort": "updateDate+desc"}, endpoint_type='summaries')
+        data = await safe_congressional_request("/summaries", None, {"limit": 10, "sort": "updateDate+desc"}, endpoint_type='summaries')
         logger.info(f"API response received: {data.keys() if isinstance(data, dict) else 'not a dict'}")  
         
         if "error" in data:
@@ -234,7 +234,7 @@ async def get_summaries_by_type(ctx: Context, congress: str, bill_type: str) -> 
         )
 
 @mcp.resource("congress://summaries/help")
-async def get_summaries_help(ctx: Context) -> str:
+async def get_summaries_help() -> str:
     """
     Get usage guide and examples for the summaries API.
     
@@ -331,7 +331,7 @@ Resource: congress://summaries/118/sres
 """
 
 @mcp.resource("congress://summaries/api-info")
-async def get_summaries_api_info(ctx: Context) -> str:
+async def get_summaries_api_info() -> str:
     """
     Get technical information about the summaries API including limits and capabilities.
     

--- a/congress_api/features/treaties.py
+++ b/congress_api/features/treaties.py
@@ -1,7 +1,7 @@
 # congress_api/features/treaties.py
 import logging
 from typing import Dict, List, Any, Optional
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.api_wrapper import safe_congressional_request
@@ -195,24 +195,24 @@ def format_treaties_list(data: Dict[str, Any]) -> str:
 
 @mcp.resource("congress://treaties/latest")
 # @require_paid_access
-async def get_latest_treaties(ctx: Context) -> str:
+async def get_latest_treaties() -> str:
     """
     Get the most recent treaties.
     Returns the 10 most recently published treaties by default.
     """
     logger.debug("Getting latest treaties")
-    
+
     try:
         # Set up parameters for the API request
         params = {
             'format': 'json',
             'limit': 10
         }
-        
+
         # Make the defensive API request
         data = await safe_congressional_request(
             endpoint="/treaty",
-            ctx=ctx,
+            ctx=None,
             params=params
         )
         
@@ -809,7 +809,7 @@ async def search_treaties(
 
 @mcp.resource("congress://treaties/help")
 # @require_paid_access
-async def get_treaties_help(ctx: Context) -> str:
+async def get_treaties_help() -> str:
     """
     Get comprehensive help and usage guide for the Treaties API.
     """
@@ -970,7 +970,7 @@ For additional help or to report issues:
 
 @mcp.resource("congress://treaties/api-info")
 # @require_paid_access
-async def get_treaties_api_info(ctx: Context) -> str:
+async def get_treaties_api_info() -> str:
     """
     Get technical API information for the Treaties API.
     """

--- a/congress_api/features/treaties_and_summaries_tool.py
+++ b/congress_api/features/treaties_and_summaries_tool.py
@@ -7,8 +7,8 @@ all treaty and summary-related operations through a clean, structured interface.
 
 import logging
 from typing import Optional
-from mcp.server.fastmcp import Context
-from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.mcpserver import Context
+from mcp.server.mcpserver.exceptions import ToolError
 from ..mcp_app import mcp
 
 logger = logging.getLogger(__name__)

--- a/congress_api/main.py
+++ b/congress_api/main.py
@@ -1,6 +1,6 @@
 """
 Main application setup for the Congressional MCP server.
-Handles FastMCP server creation, routing, and middleware configuration.
+Handles MCP server creation, routing, and middleware configuration.
 """
 
 # Load environment configuration first

--- a/congress_api/mcp_server.py
+++ b/congress_api/mcp_server.py
@@ -1,18 +1,11 @@
 # mcp_server.py - Pure MCP server with tool registrations only
-import os
-
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from .core.client_handler import app_lifespan
 
-# Transport is configurable: "stdio" (default, local) or "streamable-http" (hosted)
-TRANSPORT = os.getenv("MCP_TRANSPORT", "stdio")
-
-mcp = FastMCP(
+mcp = MCPServer(
     "Congress MCP",
     instructions="Access 91+ congressional data tools via the Congress.gov API",
-    dependencies=["httpx", "python-dotenv"],
     lifespan=app_lifespan,
-    stateless_http=(TRANSPORT == "streamable-http"),
 )
 
 def initialize_mcp_features():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "mcp>=1.26.0",
+    "mcp>=2.0.0,<3",
     "httpx>=0.28.1",
     "pydantic>=2.11.5",
     "pydantic-settings>=2.9.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,35 +1,36 @@
 # Core MCP dependencies
-mcp>=1.26.0
+mcp>=2.0.0,<3
 httpx==0.28.1
-pydantic==2.11.5
-pydantic-settings==2.9.1
+pydantic>=2.12.0
+pydantic-settings>=2.9.1
 python-dotenv==1.1.0
 requests==2.32.3
 python-dateutil==2.9.0.post0
-starlette==0.46.2
-uvicorn==0.34.3
+starlette>=0.48.0
+uvicorn>=0.34.3
 rich==14.0.0
 
-# Transitive dependencies (pinned for reproducibility)
-annotated-types==0.7.0
-anyio==4.9.0
-certifi==2025.4.26
-charset-normalizer==3.4.2
-click==8.2.1
-exceptiongroup==1.3.0
-h11==0.16.0
-httpcore==1.0.9
-httpx-sse==0.4.0
-idna==3.10
-markdown-it-py==3.0.0
-mdurl==0.1.2
-packaging==25.0
-pydantic_core==2.33.2
-Pygments==2.19.1
-shellingham==1.5.4
-sniffio==1.3.1
-sse-starlette==2.3.6
-typing-inspection==0.4.1
-typing_extensions==4.13.2
-urllib3==2.4.0
-websockets==14.1
+# Transitive dependencies (floors only below this line — mcp v2 pulls in
+# several of these transitively at versions newer than the old mcp v1 tree
+# required; re-pin exact versions via `pip freeze` after installing)
+annotated-types>=0.7.0
+anyio>=4.10
+certifi>=2025.4.26
+charset-normalizer>=3.4.2
+click>=8.2.1
+exceptiongroup>=1.3.0
+h11>=0.16.0
+httpcore>=1.0.9
+idna>=3.10
+markdown-it-py>=3.0.0
+mdurl>=0.1.2
+packaging>=25.0
+pydantic_core>=2.33.2
+Pygments>=2.19.1
+shellingham>=1.5.4
+sniffio>=1.3.1
+sse-starlette>=3.0.0
+typing-inspection>=0.4.1
+typing_extensions>=4.14.1
+urllib3>=2.4.0
+websockets>=14.1


### PR DESCRIPTION
mcp>=1.26.0 had no upper bound, so a fresh install already resolved to the newly-released v2.0.0 (2026-07-28) — which the code didn't support (v1-only FastMCP import paths, stateless_http passed to the constructor). Migrate properly instead of just pinning back to v1:

- Rename FastMCP -> MCPServer (mcp.server.mcpserver) across the server entrypoint and all Context/ToolError imports in congress_api/features
- Move stateless_http from the MCPServer constructor to streamable_http_app() at call time, per v2's transport API changes
- Bump dependency floors (anyio, pydantic, starlette, sse-starlette) to satisfy v2's actual requirements; drop the now-superseded httpx-sse

v2 also rejects Context injection on static (non-templated) resources, which broke ~20 resource handlers that used ctx to reach the shared AppContext (httpx client/API key/cache). Added a module-level AppContext accessor (get_app_context() in client_handler.py) as the Context-free path for those handlers, and widened the make_api_request/safe_*_request wrapper chain to accept ctx=None.

Verified via a clean-venv install, stdio and streamable-http boot, and the full test suite (80 passed), and actual usage in Claude Desktop of the clean-venv version.