### PR TITLE
Fix P1 defects from the 2026-08-21 functional review (#49, #50, #51, #52)

### DIFF
--- a/congress_api/core/congress_dates.py
+++ b/congress_api/core/congress_dates.py
@@ -1,0 +1,36 @@
+"""Congress-number / calendar helpers.
+
+Congress N convenes on January 3 of year 1789 + 2*(N-1) and runs two years.
+Kept free of network and server imports so feature modules and tests can use
+it directly.
+"""
+from datetime import date, datetime, timezone
+from typing import Optional
+
+
+def congress_start_year(congress: int) -> int:
+    """First calendar year of the given Congress (119 -> 2025)."""
+    return 1789 + 2 * (congress - 1)
+
+
+def congress_start_date(congress: int) -> date:
+    """Convening date of the given Congress (January 3 of its first year)."""
+    return date(congress_start_year(congress), 1, 3)
+
+
+def current_congress(today: Optional[date] = None) -> int:
+    """Congress in session on `today` (UTC) -- defaults to now.
+
+    Between January 1 and January 2 of an odd year the previous Congress is
+    still seated, so those two days roll back by one.
+    """
+    today = today or datetime.now(timezone.utc).date()
+    congress = (today.year - 1789) // 2 + 1
+    if today.year % 2 == 1 and today < date(today.year, 1, 3):
+        congress -= 1
+    return congress
+
+
+def iso_utc(d: date) -> str:
+    """Render a date as the Congress.gov `YYYY-MM-DDT00:00:00Z` form."""
+    return f"{d.isoformat()}T00:00:00Z"

--- a/congress_api/features/members.py
+++ b/congress_api/features/members.py
@@ -4,6 +4,7 @@ from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper, safe_congressional_request
+from ..core.congress_dates import current_congress
 from ..core.exceptions import CommonErrors, format_error_response
 from ..core.response_utils import ResponseProcessor
 import logging
@@ -599,24 +600,32 @@ async def search_members(
         if current_member:
             params["currentMember"] = "true"
         
-        # Determine the best API endpoint based on provided parameters
+        # Determine the best API endpoint based on provided parameters.
+        # Prefer the congress-scoped endpoints when a congress is given; the
+        # bare /member/{state} endpoint ignores congress entirely.
         endpoint = "/member"
-        
-        # If we have specific state and district, use the district endpoint
-        if state and district:
+        if congress and state and district:
+            endpoint = f"/member/congress/{congress}/{state}/{district}"
+        elif congress and state:
+            endpoint = f"/member/congress/{congress}/{state}"
+        elif state and district:
             endpoint = f"/member/{state}/{district}"
-        # If we have state but no district, use the state endpoint
-        elif state and not district:
+        elif state:
             endpoint = f"/member/{state}"
-        # If we have congress, use the congress endpoint
         elif congress:
             endpoint = f"/member/congress/{congress}"
-        
+
+        # chamber / party / name are filtered client-side, so a single page of
+        # `limit` rows is not enough -- the matches may sit on a later page
+        # (e.g. a state's senators after its representatives).
+        needs_all_pages = any([name, chamber, party])
+
         # For name-only searches, we need comprehensive data across congresses
         # Use pagination to get all members
         if name and not any([state, congress, district, chamber, party]):
             # Progressive search strategy: current congress first, then previous
-            congress_search_order = [118, 117, 116]  # Current and recent congresses
+            newest = current_congress()
+            congress_search_order = [newest, newest - 1, newest - 2]
             
             all_members = []
             for search_congress in congress_search_order:
@@ -653,6 +662,8 @@ async def search_members(
             
             # Use the aggregated data
             data = {"members": all_members}
+        elif needs_all_pages:
+            data = await get_all_members_paginated(ctx, endpoint, params)
         else:
             # Use single endpoint request for other cases
             data = await safe_congressional_request(endpoint, ctx, params, endpoint_type='members')
@@ -740,16 +751,11 @@ async def search_members(
             # Filter by chamber if provided
             if chamber:
                 member_chamber = ""
-                if "terms" in member:
-                    terms = member["terms"]
-                    if isinstance(terms, dict) and "item" in terms:
-                        terms = terms["item"]
-                    if terms and isinstance(terms, list) and terms:
-                        # Get the most recent term
-                        latest_term = terms[-1]
-                        member_chamber = latest_term.get("chamber", "").lower()
-                
-                if chamber != member_chamber:
+                latest_term = latest_term_of(member.get("terms"))
+                if latest_term:
+                    member_chamber = latest_term.get("chamber", "").lower()
+                # API values are "House of Representatives" / "Senate"
+                if not member_chamber.startswith(chamber):
                     continue
             
             filtered_members.append(member)
@@ -956,6 +962,29 @@ async def get_all_members_paginated(ctx: Context, endpoint: str, base_params: Di
         logger.error(f"Error in get_all_members_paginated: {str(e)}")
         return {"error": f"Pagination error: {str(e)}"}
 
+def latest_term_of(terms):
+    """Return the member's most recent term.
+
+    The API lists terms oldest-first, but don't rely on order: pick the term
+    with the greatest startYear (an open endYear wins ties).
+    """
+    if isinstance(terms, dict) and "item" in terms:
+        terms = terms["item"]
+    if not isinstance(terms, list) or not terms:
+        return None
+    dict_terms = [t for t in terms if isinstance(t, dict)]
+    if not dict_terms:
+        return None
+
+    def _key(t):
+        start = t.get("startYear")
+        start = int(start) if str(start).isdigit() else -1
+        open_ended = 1 if t.get("endYear") in (None, "", "Present") else 0
+        return (start, open_ended)
+
+    return max(dict_terms, key=_key)
+
+
 # Formatting helpers
 def format_member_summary(member: Dict[str, Any]) -> str:
     """Format a member into a readable summary."""
@@ -1009,14 +1038,14 @@ def format_member_summary(member: Dict[str, Any]) -> str:
             terms = terms["item"]
         
         if terms and isinstance(terms, list) and len(terms) > 0:
-            latest_term = terms[0]
+            latest_term = latest_term_of(terms)
             if isinstance(latest_term, dict):
                 chamber = latest_term.get('chamber', 'Unknown')
                 result.append(f"Chamber: {chamber}")
                 
                 # Add term years if available
-                start_year = latest_term.get('startYear', 'Unknown')
-                end_year = latest_term.get('endYear', 'Present')
+                start_year = latest_term.get('startYear') or 'Unknown'
+                end_year = latest_term.get('endYear') or 'Present'
                 if start_year != 'Unknown':
                     result.append(f"Term: {start_year} - {end_year}")
     

--- a/congress_api/features/senate_communications.py
+++ b/congress_api/features/senate_communications.py
@@ -134,7 +134,7 @@ async def get_latest_senate_communications() -> str:
         
     except Exception as e:
         logger.error(f"Error in get_latest_senate_communications: {str(e)}")
-        return CommonErrors.api_server_error("/senate-communication", str(e))
+        return format_error_response(CommonErrors.api_server_error("/senate-communication", str(e)))
 
 # --- MCP Tools ---
 
@@ -188,7 +188,7 @@ async def get_senate_communication_details(
             
     except Exception as e:
         logger.error(f"Error in get_senate_communication_details: {str(e)}")
-        return CommonErrors.api_server_error(f"/senate-communication/{congress}/{communication_type}/{communication_number}", str(e))
+        return format_error_response(CommonErrors.api_server_error(f"/senate-communication/{congress}/{communication_type}/{communication_number}", str(e)))
 
 # @require_paid_access
 async def search_senate_communications(
@@ -272,4 +272,4 @@ async def search_senate_communications(
         
     except Exception as e:
         logger.error(f"Error in search_senate_communications: {str(e)}")
-        return CommonErrors.api_server_error("/senate-communication", str(e))
+        return format_error_response(CommonErrors.api_server_error("/senate-communication", str(e)))

--- a/congress_api/features/summaries.py
+++ b/congress_api/features/summaries.py
@@ -9,6 +9,8 @@ from ..core.client_handler import make_api_request
 # Reliability Framework Imports
 from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator
+from datetime import datetime, timedelta, timezone
+from ..core.congress_dates import congress_start_date, iso_utc
 from ..core.exceptions import CommonErrors, format_error_response
 from ..core.response_utils import SummariesProcessor, clean_summaries_response
 
@@ -537,11 +539,19 @@ async def search_summaries(
             "sort": sort
         }
         
-        # Add optional date filters if provided
-        if fromDateTime:
-            params["fromDateTime"] = fromDateTime
-        if toDateTime:
-            params["toDateTime"] = toDateTime
+        # Congress.gov returns an empty list from /summaries[/congress] unless a
+        # date range is supplied, so default one: the whole Congress when a
+        # congress is given, otherwise the last 90 days.
+        now = datetime.now(timezone.utc)
+        if not fromDateTime:
+            if congress is not None:
+                fromDateTime = iso_utc(congress_start_date(congress))
+            else:
+                fromDateTime = iso_utc((now - timedelta(days=90)).date())
+        if not toDateTime:
+            toDateTime = iso_utc((now + timedelta(days=1)).date())
+        params["fromDateTime"] = fromDateTime
+        params["toDateTime"] = toDateTime
         
         # Build endpoint
         endpoint = "/summaries"
@@ -563,7 +573,12 @@ async def search_summaries(
         summaries = clean_summaries_response(data, limit=100)  # Get more for filtering
         
         if not summaries:
-            return f"No summaries found for the specified criteria."
+            upstream = (data.get("pagination") or {}).get("count")
+            scope = f"{fromDateTime[:10]} to {toDateTime[:10]}"
+            if upstream == 0:
+                return (f"No summaries found: Congress.gov reports 0 summaries "
+                        f"for {endpoint} between {scope}.")
+            return f"No summaries found for the specified criteria ({scope})."
 
         # Client-side keyword filtering only when a keyword was supplied; otherwise
         # browse the recent summaries list as-is.

--- a/congress_api/features/treaties.py
+++ b/congress_api/features/treaties.py
@@ -193,6 +193,22 @@ def format_treaties_list(data: Dict[str, Any]) -> str:
 
 # --- MCP Resources ---
 
+
+def _treaty_record(response):
+    """Return the treaty dict from a /treaty/{congress}/{number}[/{suffix}] response.
+
+    Congress.gov wraps the record in a one-element list (`"treaty": [ {...} ]`)
+    and answers a nonexistent treaty with HTTP 200 and an empty list rather
+    than a 404. Older responses used a bare dict; accept both. Returns None
+    when there is no record.
+    """
+    if not isinstance(response, dict):
+        return None
+    treaty = response.get('treaty')
+    if isinstance(treaty, list):
+        treaty = treaty[0] if treaty else None
+    return treaty if isinstance(treaty, dict) else None
+
 @mcp.resource("congress://treaties/latest")
 # @require_paid_access
 async def get_latest_treaties() -> str:
@@ -308,20 +324,14 @@ async def get_treaty_detail(ctx: Context, congress: int, treaty_number: int) -> 
         params = {'format': 'json'}
         response = await safe_congressional_request(endpoint, ctx, params, endpoint_type='treaties')
         
-        if not response or 'treaty' not in response:
-            error_response = CommonErrors.not_found(
+        treaty_data = _treaty_record(response)
+        if treaty_data is None:
+            error_response = CommonErrors.data_not_found(
                 resource_type="treaty",
-                identifier=f"{congress}/{treaty_number}",
-                suggestions=[
-                    "Verify the congress number and treaty number are correct",
-                    f"Try searching for treaties in Congress {congress} first",
-                    "Check if the treaty exists using the search_treaties tool"
-                ]
-            )
+                identifier=f"{congress}/{treaty_number}")
             return format_error_response(error_response)
         
         # Extract treaty data and format
-        treaty_data = response['treaty']
         return format_treaty_detail(treaty_data)
         
     except Exception as e:
@@ -347,20 +357,14 @@ async def get_treaty_detail_with_suffix(ctx: Context, congress: int, treaty_numb
         params = {'format': 'json'}
         response = await safe_congressional_request(endpoint, ctx, params, endpoint_type='treaties')
         
-        if not response or 'treaty' not in response:
-            error_response = CommonErrors.not_found(
+        treaty_data = _treaty_record(response)
+        if treaty_data is None:
+            error_response = CommonErrors.data_not_found(
                 resource_type="treaty",
-                identifier=f"{congress}/{treaty_number}/{treaty_suffix}",
-                suggestions=[
-                    "Verify the congress number, treaty number, and suffix are correct",
-                    f"Try checking if Treaty {congress}-{treaty_number} exists without suffix first",
-                    "Verify the suffix format (single uppercase letter like 'A', 'B')"
-                ]
-            )
+                identifier=f"{congress}/{treaty_number}/{treaty_suffix}")
             return format_error_response(error_response)
         
         # Extract treaty data and format
-        treaty_data = response['treaty']
         return format_treaty_detail(treaty_data)
         
     except Exception as e:
@@ -564,18 +568,14 @@ async def get_treaty_text(
         # Make API request
         response = await safe_congressional_request(endpoint, ctx, params, endpoint_type='treaties')
         
-        if not response or 'treaty' not in response:
-            return CommonErrors.not_found(
-                resource_type="treaty text",
-                identifier=f"{congress}/{treaty_number}" + (f"/{treaty_suffix}" if treaty_suffix else ""),
-                suggestions=[
-                    "Verify the congress number and treaty number are correct",
-                    "Check if the treaty has been processed and has available text",
-                    "Some treaties may not have text available if still under review"
-                ]
-            )
+        treaty_data = _treaty_record(response)
+        if treaty_data is None:
+            ident = f"{congress}/{treaty_number}"
+            if treaty_suffix:
+                ident += f"/{treaty_suffix}"
+            return format_error_response(CommonErrors.data_not_found(
+                resource_type="treaty text", identifier=ident))
         
-        treaty_data = response['treaty']
         
         # Format treaty text response
         result = []
@@ -680,10 +680,10 @@ async def get_treaty_text(
         
     except Exception as e:
         logger.error(f"Error getting treaty text for {congress}/{treaty_number}: {str(e)}")
-        return CommonErrors.api_server_error(
+        return format_error_response(CommonErrors.api_server_error(
             endpoint=f"/treaty/{congress}/{treaty_number}",
             message=f"Failed to retrieve treaty text: {str(e)}"
-        )
+        ))
 
 # @require_paid_access
 async def search_treaties(

--- a/tests/test_review_p1_fixes.py
+++ b/tests/test_review_p1_fixes.py
@@ -1,0 +1,296 @@
+"""Regression tests for the 2026-08-21 functional-review P1 batch.
+
+Covers issues #49 (summaries date window), #50 (search_members endpoint /
+pagination / congress order), #51 (latest term in member summaries) and #52
+(error branches must return str, not APIErrorResponse).
+"""
+import os
+import sys
+from datetime import date
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+class FakeContext:
+    async def info(self, *_):
+        pass
+
+    async def error(self, *_):
+        pass
+
+
+def _member(bioguide, last, chamber_terms, state="New York"):
+    """Build an API-shaped member record; terms given oldest-first."""
+    return {
+        "bioguideId": bioguide,
+        "name": f"{last}, Test",
+        "directOrderName": f"Test {last}",
+        "invertedOrderName": f"{last}, Test",
+        "state": state,
+        "partyName": "Democratic",
+        "terms": {"item": [
+            {"chamber": c, "startYear": s, "endYear": e}
+            for c, s, e in chamber_terms
+        ]},
+    }
+
+
+# ---------------------------------------------------------------------------
+# congress_dates helper
+# ---------------------------------------------------------------------------
+
+def test_current_congress_math():
+    from congress_api.core.congress_dates import (
+        congress_start_date, current_congress)
+    assert current_congress(date(2026, 8, 21)) == 119
+    assert current_congress(date(2025, 1, 3)) == 119
+    assert current_congress(date(2025, 1, 2)) == 118   # not yet convened
+    assert current_congress(date(2024, 12, 31)) == 118
+    assert congress_start_date(119) == date(2025, 1, 3)
+    assert congress_start_date(118) == date(2023, 1, 3)
+
+
+# ---------------------------------------------------------------------------
+# #49 search_summaries always sends a date window
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_search_summaries_defaults_date_window_to_congress():
+    from congress_api.features import summaries as mod
+    mock = AsyncMock(return_value={"summaries": [], "pagination": {"count": 0}})
+    with patch.object(mod, "safe_congressional_request", mock):
+        out = await mod.search_summaries(FakeContext(), congress=119)
+    endpoint, _ctx, params = mock.call_args.args[:3]
+    assert endpoint == "/summaries/119"
+    assert params["fromDateTime"] == "2025-01-03T00:00:00Z"
+    assert params["toDateTime"].endswith("T00:00:00Z")
+    # Empty result names the upstream count so it is not mistaken for a
+    # keyword-filter miss.
+    assert "Congress.gov reports 0" in out
+
+
+@pytest.mark.asyncio
+async def test_search_summaries_keeps_explicit_dates():
+    from congress_api.features import summaries as mod
+    mock = AsyncMock(return_value={"summaries": [], "pagination": {"count": 0}})
+    with patch.object(mod, "safe_congressional_request", mock):
+        await mod.search_summaries(
+            FakeContext(), congress=119,
+            fromDateTime="2025-06-01T00:00:00Z",
+            toDateTime="2025-06-30T00:00:00Z")
+    params = mock.call_args.args[2]
+    assert params["fromDateTime"] == "2025-06-01T00:00:00Z"
+    assert params["toDateTime"] == "2025-06-30T00:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_search_summaries_browse_without_congress_uses_recent_window():
+    from congress_api.features import summaries as mod
+    mock = AsyncMock(return_value={"summaries": [], "pagination": {"count": 0}})
+    with patch.object(mod, "safe_congressional_request", mock):
+        await mod.search_summaries(FakeContext())
+    endpoint, _ctx, params = mock.call_args.args[:3]
+    assert endpoint == "/summaries"
+    assert "fromDateTime" in params and "toDateTime" in params
+
+
+# ---------------------------------------------------------------------------
+# #50 search_members: endpoint choice, pagination, congress order
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_search_members_state_chamber_uses_congress_endpoint_and_pages():
+    """NY has 28 current members; the senators sit past the first page of 20.
+
+    With a client-side chamber filter the search must paginate the
+    congress-scoped state endpoint, not take one page of /member/NY.
+    """
+    from congress_api.features import members as mod
+    reps = [_member(f"R{i:06d}", f"Rep{i}", [("House of Representatives", 2025, None)])
+            for i in range(26)]
+    senators = [
+        _member("S000148", "Schumer",
+                [("House of Representatives", 1981, 1999), ("Senate", 1999, None)]),
+        _member("G000555", "Gillibrand",
+                [("House of Representatives", 2007, 2009), ("Senate", 2009, None)]),
+    ]
+    mock = AsyncMock(return_value={"members": reps + senators})
+    with patch.object(mod, "safe_congressional_request", mock):
+        out = await mod.search_members(
+            FakeContext(), state="NY", chamber="senate", congress=119)
+    endpoint = mock.call_args.args[0]
+    params = mock.call_args.args[2]
+    assert endpoint == "/member/congress/119/NY"
+    assert params["limit"] == 250 and params["offset"] == 0   # paginated
+    assert "Schumer" in out and "Gillibrand" in out
+    assert "Rep0" not in out
+
+
+@pytest.mark.asyncio
+async def test_search_members_state_without_filters_is_single_request():
+    from congress_api.features import members as mod
+    mock = AsyncMock(return_value={"members": [
+        _member("A000001", "Alpha", [("House of Representatives", 2025, None)])]})
+    with patch.object(mod, "safe_congressional_request", mock):
+        await mod.search_members(FakeContext(), state="VT", limit=5)
+    endpoint = mock.call_args.args[0]
+    params = mock.call_args.args[2]
+    assert endpoint == "/member/VT"
+    assert params["limit"] == 5 and "offset" not in params
+
+
+@pytest.mark.asyncio
+async def test_search_members_name_search_starts_at_current_congress():
+    from congress_api.features import members as mod
+    seen = []
+
+    async def fake_paginated(_ctx, endpoint, _params):
+        seen.append(endpoint)
+        return {"members": []}
+
+    with patch.object(mod, "get_all_members_paginated", fake_paginated), \
+            patch.object(mod, "current_congress", lambda: 121):
+        await mod.search_members(FakeContext(), name="Nobody")
+    assert seen == ["/member/congress/121", "/member/congress/120",
+                    "/member/congress/119"]
+
+
+# ---------------------------------------------------------------------------
+# #51 format_member_summary shows the latest term
+# ---------------------------------------------------------------------------
+
+def test_format_member_summary_uses_latest_term():
+    from congress_api.features.members import format_member_summary
+    m = _member("S000148", "Schumer",
+                [("House of Representatives", 1981, 1999), ("Senate", 1999, None)])
+    out = format_member_summary(m)
+    assert "Chamber: Senate" in out
+    assert "Term: 1999 - Present" in out
+    assert "1981" not in out
+
+
+def test_latest_term_of_ignores_order():
+    from congress_api.features.members import latest_term_of
+    newest_first = [{"chamber": "Senate", "startYear": 1999, "endYear": None},
+                    {"chamber": "House of Representatives", "startYear": 1981,
+                     "endYear": 1999}]
+    assert latest_term_of(newest_first)["chamber"] == "Senate"
+    assert latest_term_of({"item": list(reversed(newest_first))})["chamber"] == "Senate"
+    assert latest_term_of([]) is None
+    assert latest_term_of(None) is None
+
+
+# ---------------------------------------------------------------------------
+# #52 error branches return str
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_treaty_text_not_found_returns_str():
+    from congress_api.features import treaties as mod
+    with patch.object(mod, "safe_congressional_request",
+                      AsyncMock(return_value={})):
+        out = await mod.get_treaty_text(FakeContext(), congress=118, treaty_number=2)
+    assert isinstance(out, str)
+    assert "DATA_NOT_FOUND" in out and "SERVER_ERROR" not in out
+
+
+@pytest.mark.asyncio
+async def test_get_treaty_text_exception_returns_str():
+    from congress_api.features import treaties as mod
+    with patch.object(mod, "safe_congressional_request",
+                      AsyncMock(side_effect=RuntimeError("boom"))):
+        out = await mod.get_treaty_text(FakeContext(), congress=118, treaty_number=2)
+    assert isinstance(out, str)
+
+
+@pytest.mark.asyncio
+async def test_senate_communications_exceptions_return_str():
+    from congress_api.features import senate_communications as mod
+    boom = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch.object(mod, "safe_congressional_request", boom):
+        outs = [
+            await mod.get_latest_senate_communications(),
+            await mod.get_senate_communication_details(
+                FakeContext(), congress=119, communication_type="ec",
+                communication_number=1),
+            await mod.search_senate_communications(FakeContext(), congress=119),
+        ]
+    assert all(isinstance(o, str) for o in outs)
+
+
+def test_no_feature_returns_raw_common_errors():
+    """Static guard: every CommonErrors.* return must be wrapped."""
+    import re
+    root = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                        "congress_api", "features")
+    offenders = []
+    for dirpath, _dirs, files in os.walk(root):
+        for f in files:
+            if not f.endswith(".py"):
+                continue
+            path = os.path.join(dirpath, f)
+            with open(path) as fh:
+                for n, line in enumerate(fh, 1):
+                    if re.search(r"return\s+CommonErrors\.", line) and \
+                            "format_error_response" not in line:
+                        offenders.append(f"{path}:{n}")
+    assert offenders == []
+
+
+# ---------------------------------------------------------------------------
+# #52 follow-on: /treaty/{congress}/{number} returns a one-element list
+# ---------------------------------------------------------------------------
+
+_TREATY = {
+    "congressReceived": 118, "number": 2, "suffix": "", "topic": "Taxation",
+    "transmittedDate": "2023-03-01", "updateDate": "2024-01-01T00:00:00Z",
+    "titles": [{"title": "Tax Convention with Chile", "titleType": "Treaty - Formal Title"}],
+    "resolutionText": "<p>Resolved (two-thirds of the Senators present concurring therein)</p>",
+    "parts": {"count": 0}, "actions": {"count": 3}, "relatedDocs": [],
+    "indexTerms": [{"name": "Chile"}], "countriesParties": [{"name": "Chile"}],
+    "inForceDate": None, "oldNumber": None, "oldNumberDisplayName": None,
+}
+
+
+@pytest.mark.asyncio
+async def test_get_treaty_text_handles_list_shaped_record():
+    from congress_api.features import treaties as mod
+    with patch.object(mod, "safe_congressional_request",
+                      AsyncMock(return_value={"treaty": [_TREATY]})):
+        out = await mod.get_treaty_text(FakeContext(), congress=118, treaty_number=2)
+    assert isinstance(out, str)
+    assert "Chile" in out and "Error" not in out
+
+
+@pytest.mark.asyncio
+async def test_get_treaty_detail_handles_list_shaped_record():
+    from congress_api.features import treaties as mod
+    with patch.object(mod, "safe_congressional_request",
+                      AsyncMock(return_value={"treaty": [_TREATY]})):
+        out = await mod.get_treaty_detail(FakeContext(), congress=118, treaty_number=2)
+    assert isinstance(out, str)
+    assert "Chile" in out and "Error" not in out
+
+
+@pytest.mark.asyncio
+async def test_treaty_empty_list_is_not_found_not_server_error():
+    """Nonexistent treaty => HTTP 200 with `treaty: []`, not a 404."""
+    from congress_api.features import treaties as mod
+    with patch.object(mod, "safe_congressional_request",
+                      AsyncMock(return_value={"treaty": []})):
+        out = await mod.get_treaty_text(FakeContext(), congress=118, treaty_number=99999)
+    assert isinstance(out, str)
+    assert "DATA_NOT_FOUND" in out
+    assert "SERVER_ERROR" not in out and "has no attribute" not in out
+
+
+def test_treaty_record_accepts_dict_and_list():
+    from congress_api.features.treaties import _treaty_record
+    assert _treaty_record({"treaty": {"number": 1}}) == {"number": 1}
+    assert _treaty_record({"treaty": [{"number": 1}]}) == {"number": 1}
+    assert _treaty_record({"treaty": []}) is None
+    assert _treaty_record({}) is None
+    assert _treaty_record(None) is None


### PR DESCRIPTION
First batch from the [live functional review](https://github.com/amurshak/congressMcpFiles/blob/master/docs/reviews/2026-08-21-functional-review.md): the four small, local fixes that each remove a wrong answer a user hits in their first session.

## What changed

**#49 `search_summaries` always empty** — Congress.gov's `/summaries[/{congress}]` now returns `count: 0` unless a date range is sent. Default the window (whole Congress, or last 90 days with no congress); explicit dates still win; the empty message reports the upstream count.

**#50 `search_members`** — use `/member/congress/{congress}/{state}` when a congress is given (the bare `/member/{state}` ignored it); paginate whenever chamber/party/name are filtered client-side (NY's senators sit after its first 20 reps, so `state=NY, chamber=senate` returned nothing); derive the name-search congress order from the calendar instead of the literal `[118, 117, 116]` so 119th freshmen are findable.

**#51 `format_member_summary`** — showed `terms[0]` (oldest). New `latest_term_of()` picks the greatest `startYear`; null `endYear` renders as `Present`.

**#52 raw `APIErrorResponse` returns** — wrapped all five sites (`treaties.py` ×2, `senate_communications.py` ×3). Doing so surfaced two more bugs on the same path, fixed here: `/treaty/{c}/{n}` returns the record as a **one-element list** (and an empty list, HTTP 200, for a nonexistent treaty) — all three treaty handlers indexed it as a dict; and the not-found branches called `CommonErrors.not_found`, which doesn't exist.

New `congress_api/core/congress_dates.py` (pure date math, no I/O) is shared by the members and summaries fixes.

## Verification
- `tests/test_review_p1_fixes.py` — 17 tests incl. a static guard that no feature module returns an unwrapped `CommonErrors.*`.
- `tests/check_known_failures.py` and `scripts/audit_tool_schemas.py --check` unchanged vs master (locally only the known Py3.10 `Mock` failures from #45 appear; CI is 3.12).
- Live, through the real stdio transport:
  - `search_summaries(congress=119)` → 3 summaries; `keywords="veterans"` → 2
  - `search_members(state="NY", chamber="senate", congress=119)` → Schumer + Gillibrand, both "Chamber: Senate"
  - `search_members(name="Riley")` → finds 119th freshman Josh Riley
  - `get_treaty_text(118, 2)` → formatted record; `(118, 99999)` → `DATA_NOT_FOUND`, not `SERVER_ERROR`
- Ruff error count on every touched file is ≤ master (−3 members, −1 summaries, ±0 treaties/senate_communications).

Closes #49, closes #50, closes #51, closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)