### PR TITLE
Report Congress.gov 404/400 as NOT_FOUND / INVALID_PARAMETERS instead of SERVER_ERROR (#53)

### DIFF
--- a/congress_api/core/api_wrapper.py
+++ b/congress_api/core/api_wrapper.py
@@ -6,7 +6,7 @@ from typing import Dict, Any, Optional
 from dataclasses import dataclass, replace
 from mcp.server.mcpserver import Context
 from .client_handler import make_api_request
-from .exceptions import APIErrorResponse
+from .exceptions import APIErrorResponse, CongressionalAPIError
 
 @dataclass
 class APIEndpointConfig:
@@ -78,13 +78,28 @@ class DefensiveAPIWrapper:
                 if any(x in str(e).lower() for x in ["404", "not found", "400", "bad request"]): break
         
         error_response = DefensiveAPIWrapper._format_api_error(endpoint, last_error, config.retry_count)
-        raise Exception(error_response.message)
+        # Raise the *typed* error so handlers can report not-found / bad-request
+        # faithfully instead of collapsing everything into SERVER_ERROR.
+        raise CongressionalAPIError(error_response)
     
     @staticmethod
     def _format_api_error(endpoint: str, error: Exception, retry_count: int) -> APIErrorResponse:
+        resp = DefensiveAPIWrapper._classify_api_error(endpoint, error, retry_count)
+        resp.details = {**(resp.details or {}), "endpoint": endpoint}
+        return resp
+
+    @staticmethod
+    def _classify_api_error(endpoint: str, error: Exception, retry_count: int) -> APIErrorResponse:
         error_str = str(error).lower()
         if "timeout" in error_str: return APIErrorResponse("timeout", f"API request timed out after {retry_count + 1} attempts", ["Try again"], "API_TIMEOUT")
-        elif "404" in error_str or "not found" in error_str: return APIErrorResponse("not_found", "Data not found. Check parameters.", ["Verify parameters"], "DATA_NOT_FOUND")
+        elif "404" in error_str or "not found" in error_str:
+            return APIErrorResponse(
+                "not_found",
+                f"Not found: {endpoint}. The resource does not exist at Congress.gov.",
+                ["Check the identifiers (congress, type, number / bioguide id) for typos",
+                 "Confirm the item exists with a list/search operation first",
+                 "This is not a server outage; retrying will not help"],
+                "DATA_NOT_FOUND")
         elif "400" in error_str or "bad request" in error_str: return APIErrorResponse("validation", "Invalid parameters.", ["Check format"], "INVALID_PARAMETERS")
         elif "500" in error_str: return APIErrorResponse("server_error", "API issues.", ["Try later"], "SERVER_ERROR")
         else: return APIErrorResponse("api_failure", f"Failed after {retry_count + 1} attempts: {error}", ["Try later"], "GENERAL_API_FAILURE")

--- a/congress_api/core/api_wrapper.py
+++ b/congress_api/core/api_wrapper.py
@@ -13,6 +13,13 @@ class APIEndpointConfig:
     timeout: float = 10.0; retry_count: int = 1; retry_delay: float = 1.0; max_retry_delay: float = 5.0
     backoff_multiplier: float = 2.0; sanitize_params: bool = True; remove_empty_params: bool = True
 
+class _HTTPStatusFailure(Exception):
+    """Internal: carries the HTTP status from make_api_request's error dict."""
+    def __init__(self, status_code, message):
+        self.status_code = status_code
+        super().__init__(f"API Error ({status_code}): {message}")
+
+
 class DefensiveAPIWrapper:
     ENDPOINT_CONFIGS = {
         'bound_congressional_record': APIEndpointConfig(timeout=15.0, retry_count=2, retry_delay=2.0),
@@ -68,14 +75,15 @@ class DefensiveAPIWrapper:
                 
                 response = await make_api_request(endpoint, ctx, sanitized_params)
                 if isinstance(response, dict) and 'error' in response:
-                    error_msg = response.get('error', 'Unknown API error'); status_code = response.get('status_code', 'Unknown')
-                    if status_code == 404: raise Exception(f"404 Not Found: {error_msg}")
-                    elif status_code == 400: raise Exception(f"400 Bad Request: {error_msg}")
-                    else: raise Exception(f"API Error ({status_code}): {error_msg}")
+                    raise _HTTPStatusFailure(response.get('status_code'),
+                                             response.get('error', 'Unknown API error'))
                 return response
             except Exception as e:
                 last_error = e
-                if any(x in str(e).lower() for x in ["404", "not found", "400", "bad request"]): break
+                # Client errors are definitive: never retry a 404/400.
+                status = getattr(e, "status_code", None)
+                if status in (400, 404): break
+                if status is None and any(x in str(e).lower() for x in ["404", "not found", "400", "bad request"]): break
         
         error_response = DefensiveAPIWrapper._format_api_error(endpoint, last_error, config.retry_count)
         # Raise the *typed* error so handlers can report not-found / bad-request
@@ -89,17 +97,35 @@ class DefensiveAPIWrapper:
         return resp
 
     @staticmethod
+    def _not_found(endpoint: str) -> APIErrorResponse:
+        return APIErrorResponse(
+            "not_found",
+            f"Not found: {endpoint}. The resource does not exist at Congress.gov.",
+            ["Check the identifiers (congress, type, number / bioguide id) for typos",
+             "Confirm the item exists with a list/search operation first",
+             "This is not a server outage; retrying will not help"],
+            "DATA_NOT_FOUND")
+
+    @staticmethod
     def _classify_api_error(endpoint: str, error: Exception, retry_count: int) -> APIErrorResponse:
+        # Prefer the real HTTP status when we have one; the substring fallback
+        # below can misfire on endpoints whose path happens to contain '404'.
+        status = getattr(error, "status_code", None)
+        if status == 404:
+            return DefensiveAPIWrapper._not_found(endpoint)
+        if status == 400:
+            return APIErrorResponse("validation", f"Congress.gov rejected the request to {endpoint} (400).",
+                                    ["Check parameter names, formats and ranges"], "INVALID_PARAMETERS")
+        if status == 429:
+            return APIErrorResponse("rate_limit", f"Congress.gov rate limit hit on {endpoint} (429).",
+                                    ["Wait a minute and retry", "Reduce request volume"], "RATE_LIMIT_EXCEEDED")
+        if isinstance(status, int) and status >= 500:
+            return APIErrorResponse("server_error", f"Congress.gov returned {status} for {endpoint}.",
+                                    ["Try again in a few minutes"], "SERVER_ERROR")
         error_str = str(error).lower()
         if "timeout" in error_str: return APIErrorResponse("timeout", f"API request timed out after {retry_count + 1} attempts", ["Try again"], "API_TIMEOUT")
         elif "404" in error_str or "not found" in error_str:
-            return APIErrorResponse(
-                "not_found",
-                f"Not found: {endpoint}. The resource does not exist at Congress.gov.",
-                ["Check the identifiers (congress, type, number / bioguide id) for typos",
-                 "Confirm the item exists with a list/search operation first",
-                 "This is not a server outage; retrying will not help"],
-                "DATA_NOT_FOUND")
+            return DefensiveAPIWrapper._not_found(endpoint)
         elif "400" in error_str or "bad request" in error_str: return APIErrorResponse("validation", "Invalid parameters.", ["Check format"], "INVALID_PARAMETERS")
         elif "500" in error_str: return APIErrorResponse("server_error", "API issues.", ["Try later"], "SERVER_ERROR")
         else: return APIErrorResponse("api_failure", f"Failed after {retry_count + 1} attempts: {error}", ["Try later"], "GENERAL_API_FAILURE")

--- a/congress_api/features/amendments_tool.py
+++ b/congress_api/features/amendments_tool.py
@@ -9,6 +9,7 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
+from ..core.exceptions import CongressionalAPIError
 from ..mcp_app import mcp
 from ..core.operation_routing import validate_operation_kwargs
 
@@ -129,6 +130,10 @@ async def amendments(
         raw_response = await route_amendments_operation(ctx, operation, **operation_kwargs)
         return raw_response
 
+    except CongressionalAPIError as e:
+        # Typed Congress.gov error from a handler with no try/except of its own:
+        # surface the classification instead of a generic failure.
+        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
     except ToolError:
         # Re-raise ToolError as-is (preserves access control messages)
         raise

--- a/congress_api/features/bills_tool.py
+++ b/congress_api/features/bills_tool.py
@@ -9,6 +9,7 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
+from ..core.exceptions import CongressionalAPIError
 from ..mcp_app import mcp
 from ..core.operation_routing import validate_operation_kwargs
 from ..utils.bill_parser import parse_bill_reference, validate_bill_params
@@ -207,6 +208,10 @@ async def bills(
         raw_response = await route_bills_operation(ctx, operation, **operation_kwargs)
         return raw_response
 
+    except CongressionalAPIError as e:
+        # Typed Congress.gov error from a handler with no try/except of its own:
+        # surface the classification instead of a generic failure.
+        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
     except ToolError:
         # Re-raise ToolError as-is (preserves access control messages)
         raise

--- a/congress_api/features/bound_congressional_record.py
+++ b/congress_api/features/bound_congressional_record.py
@@ -12,7 +12,7 @@ from mcp.server.mcpserver import Context
 from ..core.client_handler import make_api_request
 from ..core.validators import BoundCongressionalRecordValidator, ParameterValidator
 from ..core.api_wrapper import safe_congressional_request
-from ..core.exceptions import handle_validation_error, format_error_response, CommonErrors
+from ..core.exceptions import handle_validation_error, format_error_response, CommonErrors, CongressionalAPIError
 from ..core.response_utils import clean_bound_congressional_record_response
 from ..mcp_app import mcp
 
@@ -338,6 +338,8 @@ async def search_bound_congressional_record(
         
         return result
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in search_bound_congressional_record: {str(e)}")
         # If it's already a formatted error, return it directly

--- a/congress_api/features/buckets/amendments/api.py
+++ b/congress_api/features/buckets/amendments/api.py
@@ -11,7 +11,7 @@ from mcp.server.mcpserver import Context
 from .processors import AmendmentsDataProcessor
 from .formatters import AmendmentsFormatter
 from ....core.validators import ParameterValidator
-from ....core.exceptions import format_error_response, APIErrorResponse
+from ....core.exceptions import format_error_response, APIErrorResponse, CongressionalAPIError
 from ....core.response_utils import ResponseProcessor
 from ....core.api_wrapper import DefensiveAPIWrapper
 
@@ -90,6 +90,8 @@ async def get_amendments(
             title="Congressional Amendments"
         )
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_amendments: {str(e)}")
         return format_error_response(APIErrorResponse(
@@ -212,6 +214,8 @@ async def search_amendments(
             duplicates_removed=duplicates_removed
         )
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in search_amendments: {str(e)}")
         return format_error_response(APIErrorResponse(
@@ -294,6 +298,8 @@ async def get_amendment_details(
 
         return AmendmentsFormatter.format_amendment_details(amendment_data)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_amendment_details: {str(e)}")
         return format_error_response(APIErrorResponse(
@@ -382,6 +388,8 @@ async def get_amendment_actions(
             actions, amendment_type, amendment_number, congress, duplicates_removed
         )
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_amendment_actions: {str(e)}")
         return format_error_response(APIErrorResponse(
@@ -470,6 +478,8 @@ async def get_amendment_sponsors(
             cosponsors, amendment_type, amendment_number, congress, duplicates_removed
         )
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_amendment_sponsors: {str(e)}")
         return format_error_response(APIErrorResponse(
@@ -561,6 +571,8 @@ async def get_amendment_amendments(
             duplicates_removed=duplicates_removed
         )
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_amendment_amendments: {str(e)}")
         return format_error_response(APIErrorResponse(
@@ -669,6 +681,8 @@ async def get_amendment_text(
 
         return "\n".join(result)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_amendment_text: {str(e)}")
         return format_error_response(APIErrorResponse(

--- a/congress_api/features/buckets/bills/api.py
+++ b/congress_api/features/buckets/bills/api.py
@@ -16,7 +16,7 @@ from .formatters import BillsFormatter
 
 # Import existing reliability framework
 from ....core.validators import ParameterValidator
-from ....core.exceptions import CommonErrors, format_error_response
+from ....core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -103,6 +103,8 @@ async def get_bills(
         # Standard response formatting
         return BillsFormatter.format_bills_list(response, "Bills")
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bills: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bills")
@@ -190,6 +192,8 @@ async def search_bills(
         # Format and return
         return BillsFormatter.format_bills_list(response, f"Bills matching '{keywords}'")
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in search_bills: {str(e)}")
         error_response = CommonErrors.api_server_error("search_bills")
@@ -233,6 +237,8 @@ async def get_recent_bills(
             bill_type=bill_type
         )
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_recent_bills: {str(e)}")
         error_response = CommonErrors.api_server_error("get_recent_bills")
@@ -296,6 +302,8 @@ async def get_bill_details(
         # Format and return
         return BillsFormatter.format_bill_detail(bill)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bill_details: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bill_details")
@@ -363,6 +371,8 @@ async def get_bill_actions(
         # Format and return
         return BillsFormatter.format_bill_actions(actions, congress, bill_type, bill_number)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bill_actions: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bill_actions")
@@ -395,6 +405,8 @@ async def get_bill_text_versions(
         text_versions = response.get('textVersions', [])
         return BillsFormatter.format_bill_text_versions(text_versions)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bill_text_versions: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bill_text_versions")
@@ -423,6 +435,8 @@ async def get_bill_summaries(
         summaries = response.get('summaries', [])
         return BillsFormatter.format_bill_summaries(summaries)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bill_summaries: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bill_summaries")
@@ -453,6 +467,8 @@ async def get_bill_text(
         text_versions = response.get('textVersions', [])
         return BillsFormatter.format_bill_text_versions(text_versions)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bill_text: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bill_text")
@@ -488,6 +504,8 @@ async def get_bill_amendments(
         amendments = response.get('amendments', [])
         return BillsFormatter.format_bill_amendments(amendments)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bill_amendments: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bill_amendments")
@@ -523,6 +541,8 @@ async def get_bill_committees(
         committees = response.get('committees', [])
         return BillsFormatter.format_bill_committees(committees)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bill_committees: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bill_committees")
@@ -558,6 +578,8 @@ async def get_bill_cosponsors(
         cosponsors = response.get('cosponsors', [])
         return BillsFormatter.format_bill_cosponsors(cosponsors)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bill_cosponsors: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bill_cosponsors")
@@ -593,6 +615,8 @@ async def get_bill_related_bills(
         related_bills = response.get('relatedBills', [])
         return BillsFormatter.format_bill_related_bills(related_bills)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bill_related_bills: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bill_related_bills")
@@ -630,6 +654,8 @@ async def get_bill_subjects(
         subjects = response.get('subjects', {})
         return BillsFormatter.format_bill_subjects(subjects)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bill_subjects: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bill_subjects")
@@ -665,6 +691,8 @@ async def get_bill_titles(
         titles = response.get('titles', [])
         return BillsFormatter.format_bill_titles(titles)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bill_titles: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bill_titles")
@@ -690,6 +718,8 @@ async def get_bill_content(
         # implement real chunked content fetching and wire all three through.
         return await get_bill_text_versions(ctx, congress, bill_type, bill_number)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bill_content: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bill_content")
@@ -719,6 +749,8 @@ async def get_bills_by_date_range(
             bill_type=bill_type
         )
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_bills_by_date_range: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bills_by_date_range")

--- a/congress_api/features/buckets/bills/helpers.py
+++ b/congress_api/features/buckets/bills/helpers.py
@@ -12,7 +12,7 @@ from mcp.server.mcpserver import Context
 # Import existing validation and API infrastructure
 from ....core.validators import ParameterValidator
 from ....core.api_wrapper import safe_congressional_request
-from ....core.exceptions import CommonErrors, format_error_response
+from ....core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -80,6 +80,10 @@ async def fetch_bill_data(
         # Use defensive API wrapper for the request
         return await safe_congressional_request(endpoint, ctx, query_params, endpoint_type='bills')
 
+    except CongressionalAPIError as e:
+        # Typed 404/400/5xx from the wrapper: pass it through unchanged so the
+        # caller reports NOT_FOUND instead of a generic server error.
+        return {"error": format_error_response(e.error_response)}
     except Exception as e:
         logger.error(f"Error in fetch_bill_data: {str(e)}")
         error_response = CommonErrors.api_server_error(f"bills endpoint: {endpoint if 'endpoint' in locals() else 'unknown'}")

--- a/congress_api/features/buckets/committee_intelligence.py
+++ b/congress_api/features/buckets/committee_intelligence.py
@@ -9,6 +9,7 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
+from ...core.exceptions import CongressionalAPIError
 from ...mcp_app import mcp
 from ...core.operation_routing import validate_operation_kwargs
 from ...models.responses import CommitteeIntelligenceResponse, CommitteeActivitySummary
@@ -277,6 +278,10 @@ async def committee_intelligence(
         # returning empty/zero results regardless of what the API actually returned.
         return await route_committee_intelligence_operation(ctx, operation, **operation_kwargs)
 
+    except CongressionalAPIError as e:
+        # Typed Congress.gov error from a handler with no try/except of its own:
+        # surface the classification instead of a generic failure.
+        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
     except ToolError:
         raise
     except Exception as e:

--- a/congress_api/features/buckets/laws.py
+++ b/congress_api/features/buckets/laws.py
@@ -15,6 +15,7 @@ from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
 
+from ...core.exceptions import CongressionalAPIError
 from ...mcp_app import mcp
 from ...core.api_wrapper import safe_congressional_request
 from ...core.operation_routing import validate_operation_kwargs
@@ -164,6 +165,10 @@ async def laws(
             if value is not None
         }
         return await route_laws_operation(ctx, operation, **kwargs)
+    except CongressionalAPIError as e:
+        # Typed Congress.gov error from a handler with no try/except of its own:
+        # surface the classification instead of a generic failure.
+        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
     except ToolError:
         raise
     except Exception as e:

--- a/congress_api/features/buckets/records_and_hearings.py
+++ b/congress_api/features/buckets/records_and_hearings.py
@@ -9,6 +9,7 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
+from ...core.exceptions import CongressionalAPIError
 from ...mcp_app import mcp
 from ...core.operation_routing import validate_operation_kwargs
 from ...models.responses import RecordsHearingsResponse, HearingSummary, RecordSummary
@@ -263,6 +264,10 @@ async def records_and_hearings(
         # returning empty/zero results regardless of what the API actually returned.
         return await route_records_and_hearings_operation(ctx, operation, **operation_kwargs)
 
+    except CongressionalAPIError as e:
+        # Typed Congress.gov error from a handler with no try/except of its own:
+        # surface the classification instead of a generic failure.
+        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
     except ToolError:
         raise
     except Exception as e:

--- a/congress_api/features/buckets/research_and_professional.py
+++ b/congress_api/features/buckets/research_and_professional.py
@@ -9,6 +9,7 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
+from ...core.exceptions import CongressionalAPIError
 from ...mcp_app import mcp
 from ...core.operation_routing import validate_operation_kwargs
 from ...models.responses import ResearchProfessionalResponse, ResearchSummary
@@ -189,6 +190,10 @@ async def research_and_professional(
         # returning empty/zero results regardless of what the API actually returned.
         return await route_research_and_professional_operation(ctx, operation, **operation_kwargs)
 
+    except CongressionalAPIError as e:
+        # Typed Congress.gov error from a handler with no try/except of its own:
+        # surface the classification instead of a generic failure.
+        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
     except ToolError:
         raise
     except Exception as e:

--- a/congress_api/features/buckets/voting_and_nominations.py
+++ b/congress_api/features/buckets/voting_and_nominations.py
@@ -9,6 +9,7 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
+from ...core.exceptions import CongressionalAPIError
 from ...mcp_app import mcp
 from ...core.operation_routing import validate_operation_kwargs
 from ...models.responses import VotingNominationsResponse, VoteSummary, NominationSummary
@@ -231,6 +232,10 @@ async def voting_and_nominations(
         # returning empty/zero results regardless of what the API actually returned.
         return await route_voting_and_nominations_operation(ctx, operation, **operation_kwargs)
 
+    except CongressionalAPIError as e:
+        # Typed Congress.gov error from a handler with no try/except of its own:
+        # surface the classification instead of a generic failure.
+        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
     except ToolError:
         raise
     except Exception as e:

--- a/congress_api/features/committee_meetings.py
+++ b/congress_api/features/committee_meetings.py
@@ -6,7 +6,7 @@ from ..mcp_app import mcp
 from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator
 from ..core.response_utils import ResponseProcessor
-from ..core.exceptions import format_error_response, CommonErrors, APIErrorResponse
+from ..core.exceptions import format_error_response, CommonErrors, APIErrorResponse, CongressionalAPIError
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -148,6 +148,8 @@ async def get_latest_committee_meetings(ctx: Context) -> str:
         
         return "\n".join(lines)
     
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Unexpected error in get_latest_committee_meetings: {str(e)}")
         return format_error_response(CommonErrors.api_server_error("committee meetings"))
@@ -196,6 +198,8 @@ async def get_committee_meetings_by_congress(ctx: Context, congress: int) -> str
         
         return "\n".join(lines)
     
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Unexpected error in get_committee_meetings_by_congress: {str(e)}")
         return format_error_response(CommonErrors.api_server_error("committee meetings"))
@@ -249,6 +253,8 @@ async def get_committee_meetings_by_congress_and_chamber(ctx: Context, congress:
         
         return "\n".join(lines)
     
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Unexpected error in get_committee_meetings_by_congress_and_chamber: {str(e)}")
         return format_error_response(CommonErrors.api_server_error("committee meetings"))
@@ -294,6 +300,8 @@ The list endpoints don't include committee information, which would require call
 
 Committee code requested: {committee_code}"""
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Unexpected error in get_committee_meetings_by_committee: {str(e)}")
         return format_error_response(CommonErrors.api_server_error("committee meetings"))
@@ -338,6 +346,8 @@ async def get_committee_meeting_details(ctx: Context, congress: int, chamber: st
         logger.info(f"Successfully retrieved committee meeting details for {congress}/{chamber}/{event_id}")
         return format_committee_meeting_detail(meeting_data)
     
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Unexpected error in get_committee_meeting_details: {str(e)}")
         return format_error_response(CommonErrors.api_server_error("committee meeting details"))
@@ -436,6 +446,8 @@ async def search_committee_meetings(
         
         return "\n".join(lines)
     
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Unexpected error in search_committee_meetings: {str(e)}")
         return format_error_response(CommonErrors.api_server_error("committee meetings"))

--- a/congress_api/features/committee_prints.py
+++ b/congress_api/features/committee_prints.py
@@ -6,7 +6,7 @@ from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator, ValidationResult
-from ..core.exceptions import APIErrorResponse, ErrorType, format_error_response, CommonErrors
+from ..core.exceptions import APIErrorResponse, ErrorType, format_error_response, CommonErrors, CongressionalAPIError
 from ..core.response_utils import CommitteePrintsProcessor, clean_committee_prints_response
 
 # Set up logger
@@ -114,6 +114,8 @@ async def get_latest_committee_prints(ctx: Context) -> str:
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         error = CommonErrors.api_server_error(
             f"Failed to retrieve latest committee prints: {str(e)}"
@@ -181,6 +183,8 @@ async def get_committee_prints_by_congress(ctx: Context, congress: int) -> str:
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         error = CommonErrors.api_server_error(
             f"Failed to retrieve committee prints for Congress {congress}: {str(e)}"
@@ -257,6 +261,8 @@ async def get_committee_prints_by_congress_and_chamber(ctx: Context, congress: i
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         error = CommonErrors.api_server_error(
             f"Failed to retrieve committee prints for Congress {congress}, {chamber}: {str(e)}"
@@ -352,6 +358,8 @@ async def get_committee_print_details(ctx: Context, congress: int, chamber: str,
         
         return format_committee_print_detail(print_item)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         error = CommonErrors.api_server_error(
             f"Failed to retrieve committee print details: {str(e)}"
@@ -434,6 +442,8 @@ async def get_committee_print_text_versions(ctx: Context, congress: int, chamber
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         error = CommonErrors.api_server_error(
             f"Failed to retrieve committee print text versions: {str(e)}"
@@ -540,6 +550,8 @@ async def search_committee_prints(
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         error = CommonErrors.api_server_error(
             f"Failed to search committee prints: {str(e)}"

--- a/congress_api/features/committee_reports.py
+++ b/congress_api/features/committee_reports.py
@@ -7,7 +7,7 @@ from mcp.server.mcpserver import Context
 from ..core.client_handler import make_api_request
 from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator
-from ..core.exceptions import format_error_response, CommonErrors
+from ..core.exceptions import format_error_response, CommonErrors, CongressionalAPIError
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -113,6 +113,8 @@ async def get_latest_committee_reports(ctx: Context) -> str:
         
         return result
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error fetching latest committee reports: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(
@@ -176,6 +178,8 @@ async def get_committee_reports_by_congress(ctx: Context, congress: int) -> str:
         
         return result
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error fetching committee reports for Congress {congress}: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(
@@ -254,6 +258,8 @@ async def get_committee_reports_by_congress_and_type(
         
         return result
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error fetching committee reports for Congress {congress}, type {report_type}: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(
@@ -329,6 +335,8 @@ async def get_committee_report_details(
         
         return format_committee_report_detail(report_item)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error fetching committee report details for {congress}/{report_type}/{report_number}: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(
@@ -408,6 +416,8 @@ async def get_committee_report_text_versions(
         
         return result
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error fetching text versions for committee report {congress}/{report_type}/{report_number}: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(
@@ -528,6 +538,8 @@ async def search_committee_reports(
         
         return result
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error searching committee reports: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(
@@ -758,6 +770,8 @@ async def get_committee_report_content(
             }
             return format_error_response(error_response)
             
+        except CongressionalAPIError as e:
+            return format_error_response(e.error_response)
         except Exception as e:
             logger.error(f"Unexpected error while fetching committee report content: {e}")
             error_response = CommonErrors.api_server_error("committee report content retrieval")
@@ -767,6 +781,8 @@ async def get_committee_report_content(
             }
             return format_error_response(error_response)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error fetching committee report content: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(

--- a/congress_api/features/committees.py
+++ b/congress_api/features/committees.py
@@ -6,7 +6,7 @@ from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator, ValidationResult
 from ..core.api_wrapper import DefensiveAPIWrapper
-from ..core.exceptions import CommonErrors, format_error_response
+from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
 
 # Set up logging
@@ -322,6 +322,8 @@ async def get_committee_bills(
         logger.info(f"Successfully retrieved {len(bills)} bills for committee {committee_code}")
         return "\n".join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_committee_bills: {str(e)}")
         error_response = CommonErrors.api_server_error("committee bills")
@@ -420,6 +422,8 @@ async def get_committee_reports(
         logger.info(f"Successfully retrieved {len(reports)} reports for committee {committee_code}")
         return "\n".join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_committee_reports: {str(e)}")
         error_response = CommonErrors.api_server_error("committee reports")
@@ -510,6 +514,8 @@ async def get_committee_nominations(
         logger.info(f"Successfully retrieved {len(nominations)} nominations for committee {committee_code}")
         return "\n".join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_committee_nominations: {str(e)}")
         error_response = CommonErrors.api_server_error("committee nominations")
@@ -622,6 +628,8 @@ async def get_committee_communications(
         logger.info(f"Successfully retrieved {len(communications)} communications for committee {committee_code}")
         return "\n".join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_committee_communications: {str(e)}")
         error_response = CommonErrors.api_server_error("committee communications")
@@ -713,6 +721,8 @@ async def search_committees(
         logger.info(f"Successfully found {len(committees)} committees (search='{keywords}', type='{committee_type}')")
         return "\n".join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in search_committees: {str(e)}")
         error_response = CommonErrors.api_server_error("committee search")
@@ -809,6 +819,8 @@ async def get_committee_communication_details(
         logger.info(f"Successfully retrieved communication details for {chamber} {communication_type} {communication_number}")
         return result
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_committee_communication_details: {str(e)}")
         error_response = CommonErrors.api_server_error("communication details")

--- a/congress_api/features/congress_info.py
+++ b/congress_api/features/congress_info.py
@@ -8,7 +8,7 @@ from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper
-from ..core.exceptions import CommonErrors, format_error_response
+from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
 
 # Configure logging
@@ -213,6 +213,8 @@ async def get_all_congresses() -> str:
         
         # Use default format type
         return format_congresses_list(deduplicated_congresses, "markdown")
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         error = CommonErrors.general_error(f"Error retrieving congresses: {str(e)}")
         logger.error(f"Exception in get_all_congresses: {str(e)}")
@@ -300,6 +302,8 @@ async def get_congress_info(
             )
             
             return format_congresses_list(deduplicated_congresses, format_type)
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         error = CommonErrors.general_error(f"Error retrieving Congress information: {str(e)}")
         return format_error_response(error)
@@ -438,6 +442,8 @@ async def search_congresses(
             formatted_list = format_congresses_list(limited_congresses)
             # Replace the default header with our search header
             return result_header + formatted_list[formatted_list.find("\n"):]
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         error = CommonErrors.general_error(f"Error searching congresses: {str(e)}")
         return format_error_response(error)

--- a/congress_api/features/congressional_record.py
+++ b/congress_api/features/congressional_record.py
@@ -10,7 +10,7 @@ from ..core.client_handler import make_api_request
 # Reliability Framework Imports
 from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper
-from ..core.exceptions import CommonErrors, format_error_response
+from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
 
 # Set up logger
@@ -163,6 +163,8 @@ async def get_latest_congressional_record() -> str:
             lines.append(format_record_issue(issue))
         
         return "\n".join(lines)
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         error = CommonErrors.general_error(f"Error retrieving latest congressional record issues: {str(e)}")
         logger.error(f"Exception in get_latest_congressional_record: {str(e)}")
@@ -282,6 +284,8 @@ async def search_congressional_record(
             lines.append(format_record_issue(issue))
         
         return "\n".join(lines)
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         error = CommonErrors.general_error(f"Error searching congressional record issues: {str(e)}")
         logger.error(f"Exception in search_congressional_record: {str(e)}")

--- a/congress_api/features/crs_reports.py
+++ b/congress_api/features/crs_reports.py
@@ -6,7 +6,7 @@ from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper
-from ..core.exceptions import CommonErrors, format_error_response
+from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
 
 # Set up logger
@@ -186,6 +186,8 @@ async def get_latest_crs_reports() -> str:
         # Format the response
         return format_crs_reports_list(data)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Exception in get_latest_crs_reports: {str(e)}")
         return format_error_response(CommonErrors.general_error(f"Error retrieving latest CRS reports: {str(e)}"))
@@ -307,6 +309,8 @@ async def search_crs_reports(
         else:
             return format_error_response(CommonErrors.data_not_found("No CRS reports available"))
             
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Exception in search_crs_reports: {str(e)}")
         return format_error_response(CommonErrors.general_error(f"Error searching CRS reports: {str(e)}"))

--- a/congress_api/features/daily_congressional_record.py
+++ b/congress_api/features/daily_congressional_record.py
@@ -6,7 +6,7 @@ from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper
-from ..core.exceptions import CommonErrors, format_error_response
+from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
 
 # Set up logger
@@ -184,6 +184,8 @@ async def get_latest_daily_congressional_record() -> str:
             )
             return format_error_response(error_response)
             
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error retrieving latest daily congressional record issues: {e}")
         logger.error(f"Exception type: {type(e)}")
@@ -371,6 +373,8 @@ async def search_daily_congressional_record(
                 )
                 return format_error_response(error_response)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error searching daily congressional record: {e}")
         logger.error(f"Exception type: {type(e)}")

--- a/congress_api/features/hearings.py
+++ b/congress_api/features/hearings.py
@@ -6,7 +6,7 @@ from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator, ValidationResult
 from ..core.api_wrapper import DefensiveAPIWrapper
-from ..core.exceptions import CommonErrors, format_error_response
+from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
 
 # Set up logger
@@ -126,6 +126,8 @@ async def get_latest_hearings(ctx: Optional[Context] = None) -> str:
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error retrieving latest hearings: {e}")
         logger.error(f"Exception type: {type(e)}")
@@ -225,6 +227,8 @@ async def get_hearings_by_congress(ctx: Context, congress: int) -> str:
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error retrieving hearings for Congress {congress}: {e}")
         logger.error(f"Exception type: {type(e)}")
@@ -299,6 +303,8 @@ async def get_hearings_by_congress_and_chamber(ctx: Context, congress: int, cham
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error retrieving hearings for Congress {congress}, Chamber {chamber}: {e}")
         logger.error(f"Exception type: {type(e)}")
@@ -378,6 +384,8 @@ async def get_hearing_details(ctx: Context, congress: int, chamber: str, jacket_
         logger.info(f"Successfully retrieved hearing details for {congress}/{chamber}/{jacket_number}")
         return format_hearing_detail(HearingsProcessor.clean_hearing_response(hearing_data))
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error retrieving hearing details for {congress}/{chamber}/{jacket_number}: {e}")
         logger.error(f"Exception type: {type(e)}")
@@ -512,6 +520,8 @@ async def get_hearing_content(ctx: Context, congress: int, chamber: str, jacket_
             logger.error(f"Error fetching content from {content_url}: {fetch_error}")
             return f"Error fetching hearing content from {content_url}: {str(fetch_error)}"
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error retrieving hearing content for {congress}/{chamber}/{jacket_number}: {e}")
         logger.error(f"Exception type: {type(e)}")
@@ -605,6 +615,8 @@ async def search_hearings(
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error searching hearings: {e}")
         logger.error(f"Exception type: {type(e)}")

--- a/congress_api/features/house_communications.py
+++ b/congress_api/features/house_communications.py
@@ -8,7 +8,7 @@ from ..core.client_handler import make_api_request
 # Import reliability framework components
 from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper
-from ..core.exceptions import CommonErrors, format_error_response
+from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import HouseCommunicationsProcessor
 
 # Set up logger
@@ -196,6 +196,8 @@ async def latest_house_communications_resource() -> str:
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in latest house communications resource: {str(e)}")
         return format_error_response(CommonErrors.api_server_error("/house-communication", message=str(e)))
@@ -267,6 +269,8 @@ async def get_house_communication_details(
         logger.info(f"Retrieved details for house communication {congress}/{communication_type}/{communication_number}")
         return format_house_communication_detail(comm_data)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Unexpected error getting house communication details {congress}/{communication_type}/{communication_number}: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"/house-communication/{congress}/{communication_type}/{communication_number}", message=str(e)))
@@ -369,6 +373,8 @@ async def search_house_communications(
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Unexpected error searching house communications: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(endpoint, message=str(e)))

--- a/congress_api/features/house_requirements.py
+++ b/congress_api/features/house_requirements.py
@@ -7,7 +7,7 @@ from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper
-from ..core.exceptions import CommonErrors, format_error_response
+from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
 
 # Set up logger
@@ -191,6 +191,8 @@ async def get_latest_house_requirements() -> str:
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Unexpected error fetching latest house requirements: {str(e)}")
         return format_error_response(CommonErrors.api_server_error("/house-requirement", message=str(e)))
@@ -258,6 +260,8 @@ async def search_house_requirements(
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Unexpected error searching house requirements: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(endpoint, message=str(e)))
@@ -307,6 +311,8 @@ async def get_house_requirement_details(
         logger.info(f"Found house requirement {requirement_number}")
         return format_house_requirement_detail(requirement)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Unexpected error fetching house requirement details: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(endpoint, message=str(e)))
@@ -347,6 +353,8 @@ async def get_house_requirement_matching_communications(
         logger.info(f"Found matching communications for house requirement {requirement_number}")
         return format_matching_communications(data)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Unexpected error fetching matching communications: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(endpoint, message=str(e)))

--- a/congress_api/features/house_votes.py
+++ b/congress_api/features/house_votes.py
@@ -10,7 +10,7 @@ from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.validators import ParameterValidator, ValidationResult
 from ..core.api_wrapper import safe_congressional_request
-from ..core.exceptions import CommonErrors, format_error_response
+from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
 
 logger = logging.getLogger(__name__)
@@ -378,6 +378,8 @@ async def get_latest_house_votes() -> str:
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Exception in get_latest_house_votes: {type(e).__name__}: {e}")
         logger.error(f"Exception repr: {repr(e)}")
@@ -431,6 +433,8 @@ async def get_house_votes_by_congress(ctx: Context, congress: int, limit: int = 
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Exception in get_house_votes_by_congress: {type(e).__name__}: {e}")
         logger.error(f"Exception repr: {repr(e)}")
@@ -490,6 +494,8 @@ async def get_house_votes_by_session(ctx: Context, congress: int, session: int, 
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Exception in get_house_votes_by_session: {type(e).__name__}: {e}")
         logger.error(f"Exception repr: {repr(e)}")
@@ -540,6 +546,8 @@ async def get_house_vote_details(ctx: Context, congress: int, session: int, vote
         vote = data['houseRollCallVote']
         return format_house_vote_detail(vote)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Exception in get_house_vote_details: {type(e).__name__}: {e}")
         logger.error(f"Exception repr: {repr(e)}")
@@ -605,6 +613,8 @@ async def get_house_vote_details_enhanced(ctx: Context, congress: int, session: 
         
         return f"# Enhanced House Vote Details\n\n{basic_result}{enhanced_section}"
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Enhanced function error: {type(e).__name__}: {e}")
         return format_error_response(CommonErrors.general_error(f"Error getting enhanced vote details: {str(e)}", ["Try again in a few moments", "Check your vote parameters"]))
@@ -667,6 +677,8 @@ async def get_house_vote_member_votes(ctx: Context, congress: int, session: int,
         
         return "\n".join(lines)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Exception in get_house_vote_member_votes: {type(e).__name__}: {e}")
         logger.error(f"Exception repr: {repr(e)}")
@@ -744,6 +756,8 @@ async def get_house_vote_member_votes_xml(ctx: Context, congress: int, session: 
                 f"Failed to fetch XML content: {str(fetch_error)}"
             ))
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Exception in get_house_vote_member_votes_xml: {type(e).__name__}: {e}")
         logger.error(f"Exception repr: {repr(e)}")

--- a/congress_api/features/members.py
+++ b/congress_api/features/members.py
@@ -5,7 +5,7 @@ from ..mcp_app import mcp
 from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper, safe_congressional_request
 from ..core.congress_dates import current_congress
-from ..core.exceptions import CommonErrors, format_error_response
+from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
 import logging
 
@@ -165,6 +165,8 @@ async def get_member_details(ctx: Context, bioguide_id: str) -> str:
         
         return "\n".join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_member_details: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"Unexpected error: {str(e)}"))
@@ -246,6 +248,8 @@ async def get_member_sponsored_legislation(ctx: Context, bioguide_id: str, limit
         
         return "\n".join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_member_sponsored_legislation: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"Unexpected error: {str(e)}"))
@@ -324,6 +328,8 @@ async def get_member_cosponsored_legislation(ctx: Context, bioguide_id: str, lim
         
         return "\n".join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_member_cosponsored_legislation: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"Unexpected error: {str(e)}"))
@@ -388,6 +394,8 @@ async def get_members_by_congress(ctx: Context, congress: int, current_member: O
 
         return "\n".join(result)
 
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_members_by_congress: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"Unexpected error: {str(e)}"))
@@ -449,6 +457,8 @@ async def get_members_by_state(ctx: Context, state_code: str, current_member: Op
         
         return "\n".join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_members_by_state: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"Unexpected error: {str(e)}"))
@@ -509,6 +519,8 @@ async def get_members_by_district(ctx: Context, state_code: str, district: int, 
         
         return "\n".join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_members_by_district: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"Unexpected error: {str(e)}"))
@@ -782,6 +794,8 @@ async def search_members(
         
         return "\n".join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in search_members: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"Unexpected error: {str(e)}"))
@@ -896,6 +910,8 @@ async def get_members_by_congress_state_district(
         
         return "\n".join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_members_by_congress_state_district: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"Unexpected error: {str(e)}"))

--- a/congress_api/features/members.py
+++ b/congress_api/features/members.py
@@ -641,9 +641,12 @@ async def search_members(
             
             all_members = []
             for search_congress in congress_search_order:
-                congress_members = await get_all_members_paginated(
-                    ctx, f"/member/congress/{search_congress}", params
-                )
+                try:
+                    congress_members = await get_all_members_paginated(
+                        ctx, f"/member/congress/{search_congress}", params
+                    )
+                except CongressionalAPIError:
+                    continue  # Skip this congress if error, try next
                 if "error" in congress_members:
                     continue  # Skip this congress if error, try next
                 
@@ -974,6 +977,9 @@ async def get_all_members_paginated(ctx: Context, endpoint: str, base_params: Di
         logger.info(f"Pagination complete. Total members fetched: {len(all_members)}")
         return {"members": all_members}
         
+    except CongressionalAPIError:
+        # Let the typed 404/400/5xx reach the caller's handler unchanged.
+        raise
     except Exception as e:
         logger.error(f"Error in get_all_members_paginated: {str(e)}")
         return {"error": f"Pagination error: {str(e)}"}

--- a/congress_api/features/senate_communications.py
+++ b/congress_api/features/senate_communications.py
@@ -4,7 +4,7 @@ from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
 from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator
-from ..core.exceptions import CommonErrors, format_error_response
+from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import SenateCommunicationsProcessor, clean_senate_communications_response
 
 # Set up logger
@@ -132,6 +132,8 @@ async def get_latest_senate_communications() -> str:
         logger.info(f"Found {len(processed_communications)} senate communications")
         return format_senate_communications_list(processed_communications, "Latest Senate Communications")
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_latest_senate_communications: {str(e)}")
         return format_error_response(CommonErrors.api_server_error("/senate-communication", str(e)))
@@ -186,6 +188,8 @@ async def get_senate_communication_details(
             logger.warning(f"Unexpected response format. Keys: {list(data.keys()) if isinstance(data, dict) else 'Not a dictionary'}")
             return f"Retrieved senate communication {congress_clean}/{type_clean}/{number_clean}, but in an unexpected format:\n\n{str(data)[:500]}..."
             
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in get_senate_communication_details: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(f"/senate-communication/{congress}/{communication_type}/{communication_number}", str(e)))
@@ -270,6 +274,8 @@ async def search_senate_communications(
         
         return format_senate_communications_list(processed_communications, title)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in search_senate_communications: {str(e)}")
         return format_error_response(CommonErrors.api_server_error("/senate-communication", str(e)))

--- a/congress_api/features/summaries.py
+++ b/congress_api/features/summaries.py
@@ -11,7 +11,7 @@ from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator
 from datetime import datetime, timedelta, timezone
 from ..core.congress_dates import congress_start_date, iso_utc
-from ..core.exceptions import CommonErrors, format_error_response
+from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import SummariesProcessor, clean_summaries_response
 
 # Configure logging
@@ -121,6 +121,8 @@ async def get_latest_summaries() -> str:
         logger.info(f"Returning {len(summaries)} latest summaries")
         return format_summaries_list(summaries, "Latest Bill Summaries")
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error accessing latest summaries: {str(e)}")
         return format_error_response(
@@ -171,6 +173,8 @@ async def get_summaries_by_congress(ctx: Context, congress: str) -> str:
         return format_error_response(
             CommonErrors.invalid_parameter("congress", congress, "Congress must be a valid number", ["117", "118", "119"])
         )
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error accessing summaries for Congress {congress}: {str(e)}")
         return format_error_response(
@@ -229,6 +233,8 @@ async def get_summaries_by_type(ctx: Context, congress: str, bill_type: str) -> 
         return format_error_response(
             CommonErrors.invalid_parameter("congress", congress, "Congress must be a valid number", ["117", "118", "119"])
         )
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error accessing summaries for Congress {congress}, bill type {bill_type}: {str(e)}")
         return format_error_response(
@@ -600,6 +606,8 @@ async def search_summaries(
         logger.info(f"Found {len(filtered_summaries)} summaries ({'keyword' if keywords else 'browse'} mode)")
         return format_summaries_list(filtered_summaries, title)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error searching summaries with keywords '{keywords}': {str(e)}")
         return format_error_response(
@@ -701,6 +709,8 @@ async def get_bill_summaries(
         logger.info(f"Returning {len(summaries)} summaries for {bill_type.upper()} {bill_number}")
         return "\n".join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error getting summaries for {bill_type.upper()} {bill_number} in Congress {congress}: {str(e)}")
         return format_error_response(

--- a/congress_api/features/treaties.py
+++ b/congress_api/features/treaties.py
@@ -6,7 +6,7 @@ from ..mcp_app import mcp
 from ..core.client_handler import make_api_request
 from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator
-from ..core.exceptions import CommonErrors, format_error_response
+from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import TreatiesProcessor, clean_treaties_response
 
 # Set up logger
@@ -245,6 +245,8 @@ async def get_latest_treaties() -> str:
             logger.warning(f"Unexpected response format for latest treaties: {type(data)}")
             return "No treaties data available in the expected format."
             
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error getting latest treaties: {str(e)}")
         error_response = CommonErrors.api_server_error(
@@ -302,6 +304,8 @@ async def get_treaties_by_congress(ctx: Context, congress: int) -> str:
             logger.warning(f"Unexpected response format for Congress {congress} treaties: {type(data)}")
             return f"No treaties data available for Congress {congress} in the expected format."
             
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error getting treaties for Congress {congress}: {str(e)}")
         error_response = CommonErrors.api_server_error(
@@ -334,6 +338,8 @@ async def get_treaty_detail(ctx: Context, congress: int, treaty_number: int) -> 
         # Extract treaty data and format
         return format_treaty_detail(treaty_data)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error getting treaty detail for {congress}/{treaty_number}: {str(e)}")
         error_response = CommonErrors.api_server_error(
@@ -367,6 +373,8 @@ async def get_treaty_detail_with_suffix(ctx: Context, congress: int, treaty_numb
         # Extract treaty data and format
         return format_treaty_detail(treaty_data)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error getting treaty detail for {congress}/{treaty_number}/{treaty_suffix}: {str(e)}")
         error_response = CommonErrors.api_server_error(
@@ -457,6 +465,8 @@ async def get_treaty_actions(
             logger.warning(f"Unexpected response format for treaty actions: {type(data)}")
             return f"No treaty actions data available for Congress {congress}, Treaty {treaty_number}."
             
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error getting treaty actions for Congress {congress}, Treaty {treaty_number}: {str(e)}")
         error_response = CommonErrors.api_server_error(
@@ -523,6 +533,8 @@ async def get_treaty_committees(
         # Format the response
         return format_treaty_committees(data)
     
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error getting treaty committees for Congress {congress}, Treaty {treaty_number}: {str(e)}")
         error_response = CommonErrors.api_server_error(
@@ -678,6 +690,8 @@ async def get_treaty_text(
         
         return '\n'.join(result)
         
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error getting treaty text for {congress}/{treaty_number}: {str(e)}")
         return format_error_response(CommonErrors.api_server_error(
@@ -796,6 +810,8 @@ async def search_treaties(
         # Format the response
         return format_treaties_list(data)
     
+    except CongressionalAPIError as e:
+        return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error searching for treaties: {str(e)}")
         error_response = CommonErrors.api_server_error(

--- a/congress_api/features/treaties_and_summaries_tool.py
+++ b/congress_api/features/treaties_and_summaries_tool.py
@@ -9,6 +9,7 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
+from ..core.exceptions import CongressionalAPIError
 from ..mcp_app import mcp
 from ..core.operation_routing import validate_operation_kwargs
 
@@ -127,6 +128,10 @@ async def treaties_and_summaries(
         raw_response = await route_treaties_summaries_operation(ctx, operation, **operation_kwargs)
         return raw_response
 
+    except CongressionalAPIError as e:
+        # Typed Congress.gov error from a handler with no try/except of its own:
+        # surface the classification instead of a generic failure.
+        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
     except ToolError:
         # Re-raise ToolError as-is (preserves access control messages)
         raise

--- a/tests/test_typed_api_errors.py
+++ b/tests/test_typed_api_errors.py
@@ -150,3 +150,101 @@ def test_every_generic_except_that_formats_errors_has_typed_clause_first():
                 if "except CongressionalAPIError" not in prev:
                     offenders.append(f"{os.path.relpath(f)}:{i + 1}")
     assert offenders == []
+
+
+# ---------------------------------------------------------------------------
+# critique follow-ups: pagination path, routers, status-based classification
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_search_members_filtered_path_reports_not_found():
+    """chamber/party/name searches go through get_all_members_paginated; a
+    typed 404 there must not be re-wrapped as SERVER_ERROR."""
+    from congress_api.features import members as mod
+    from congress_api.core import api_wrapper
+    with patch.object(api_wrapper, "make_api_request", AsyncMock(return_value=_api_error(404))):
+        out = await mod.search_members(FakeContext(), state="WY", chamber="senate", congress=119)
+    assert "DATA_NOT_FOUND" in out and "SERVER_ERROR" not in out
+    assert "Pagination error" not in out
+
+
+@pytest.mark.asyncio
+async def test_name_search_skips_congress_that_404s():
+    from congress_api.features import members as mod
+    from congress_api.core.exceptions import CongressionalAPIError, CommonErrors
+    calls = []
+
+    async def fake_paginated(_ctx, endpoint, _params):
+        calls.append(endpoint)
+        if len(calls) == 1:
+            raise CongressionalAPIError(CommonErrors.data_not_found("members", identifier=endpoint))
+        return {"members": []}
+
+    with patch.object(mod, "get_all_members_paginated", fake_paginated), \
+            patch.object(mod, "current_congress", lambda: 121):
+        out = await mod.search_members(FakeContext(), name="Nobody")
+    assert len(calls) == 3           # first congress skipped, search continued
+    assert isinstance(out, str)
+
+
+@pytest.mark.asyncio
+async def test_router_surfaces_typed_error_from_bare_handler():
+    """nominations.* handlers call the wrapper with no try/except; the
+    voting_and_nominations router must turn the typed error into a ToolError
+    that carries the classification, not a generic failure."""
+    from mcp.server.mcpserver.exceptions import ToolError
+    from congress_api.features.buckets import voting_and_nominations as router
+    from congress_api.core import api_wrapper
+    with patch.object(api_wrapper, "make_api_request", AsyncMock(return_value=_api_error(404))):
+        with pytest.raises(ToolError) as ei:
+            await router.voting_and_nominations(
+                FakeContext(), operation="get_nomination_details", congress=119,
+                nomination_number=999999)
+    msg = str(ei.value)
+    assert msg.startswith("DATA_NOT_FOUND:") or "DATA_NOT_FOUND:" in msg
+    assert "experiencing issues" not in msg and "❌" not in msg
+
+
+def test_every_router_has_typed_clause():
+    root = os.path.join(os.path.dirname(os.path.dirname(__file__)), "congress_api", "features")
+    routers = [f for f in glob.glob(os.path.join(root, "**", "*.py"), recursive=True)
+               if "raise ToolError" in open(f).read() and "except Exception as e:" in open(f).read()]
+    assert routers, "no router modules found"
+    missing = [os.path.relpath(f) for f in routers
+               if "except CongressionalAPIError" not in open(f).read()]
+    assert missing == []
+
+
+@pytest.mark.asyncio
+async def test_classification_uses_http_status_not_endpoint_text():
+    """An endpoint whose path contains '404' with a 500 status is a server
+    error; a 404 status whose message lacks '404' is still not-found."""
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+
+    with patch.object(mod, "make_api_request",
+                      AsyncMock(return_value={"error": "boom", "status_code": 500})), \
+            patch.object(mod.asyncio, "sleep", AsyncMock()):
+        with pytest.raises(CongressionalAPIError) as ei:
+            await mod.safe_congressional_request("/bill/119/hr/4004", FakeContext(), {},
+                                                 endpoint_type="default")
+    assert ei.value.error_response.error_code == "SERVER_ERROR"
+
+    with patch.object(mod, "make_api_request",
+                      AsyncMock(return_value={"error": "gone", "status_code": 404})):
+        with pytest.raises(CongressionalAPIError) as ei:
+            await mod.safe_congressional_request("/member/X", FakeContext(), {})
+    assert ei.value.error_response.error_code == "DATA_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_429_is_rate_limit_not_server_error():
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+    with patch.object(mod, "make_api_request",
+                      AsyncMock(return_value={"error": "slow down", "status_code": 429})), \
+            patch.object(mod.asyncio, "sleep", AsyncMock()):
+        with pytest.raises(CongressionalAPIError) as ei:
+            await mod.safe_congressional_request("/bill/119", FakeContext(), {},
+                                                 endpoint_type="default")
+    assert ei.value.error_response.error_code == "RATE_LIMIT_EXCEEDED"

--- a/tests/test_typed_api_errors.py
+++ b/tests/test_typed_api_errors.py
@@ -1,0 +1,152 @@
+"""Issue #53: a Congress.gov 404/400 must reach the user as NOT_FOUND /
+INVALID_PARAMETERS, not as "The Congressional API is experiencing issues".
+
+Covers the wrapper (raises the typed CongressionalAPIError), representative
+handlers (pass it through), and a static guard that every generic
+`except Exception` in a handler module is preceded by the typed clause.
+"""
+import glob
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+class FakeContext:
+    async def info(self, *_):
+        pass
+
+    async def error(self, *_):
+        pass
+
+
+def _api_error(status):
+    return {"error": f"API request failed: {status}", "status_code": status,
+            "request_time": 0.1}
+
+
+# ---------------------------------------------------------------------------
+# wrapper
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_wrapper_raises_typed_not_found_on_404():
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+    with patch.object(mod, "make_api_request", AsyncMock(return_value=_api_error(404))):
+        with pytest.raises(CongressionalAPIError) as ei:
+            await mod.safe_congressional_request("/bill/119/hr/9999999", FakeContext(), {})
+    err = ei.value.error_response
+    assert err.error_code == "DATA_NOT_FOUND"
+    assert err.error_type == "not_found"
+    assert err.details["endpoint"] == "/bill/119/hr/9999999"
+    assert "retrying will not help" in " ".join(err.suggestions)
+
+
+@pytest.mark.asyncio
+async def test_wrapper_does_not_retry_404():
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+    mock = AsyncMock(return_value=_api_error(404))
+    with patch.object(mod, "make_api_request", mock), \
+            pytest.raises(CongressionalAPIError):
+        await mod.safe_congressional_request("/bill/119", FakeContext(), {},
+                                             endpoint_type="bills")  # retry_count=3
+    assert mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_wrapper_raises_typed_invalid_on_400():
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+    with patch.object(mod, "make_api_request", AsyncMock(return_value=_api_error(400))):
+        with pytest.raises(CongressionalAPIError) as ei:
+            await mod.safe_congressional_request("/bill/119", FakeContext(), {})
+    assert ei.value.error_response.error_code == "INVALID_PARAMETERS"
+
+
+@pytest.mark.asyncio
+async def test_wrapper_keeps_server_error_for_5xx():
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+    with patch.object(mod, "make_api_request", AsyncMock(return_value=_api_error(500))), \
+            patch.object(mod.asyncio, "sleep", AsyncMock()):
+        with pytest.raises(CongressionalAPIError) as ei:
+            await mod.safe_congressional_request("/bill/119", FakeContext(), {},
+                                                 endpoint_type="default")
+    assert ei.value.error_response.error_code == "SERVER_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# handlers pass the typed error through
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_member_details_reports_not_found():
+    from congress_api.features import members as mod
+    from congress_api.core import api_wrapper
+    with patch.object(api_wrapper, "make_api_request", AsyncMock(return_value=_api_error(404))):
+        out = await mod.get_member_details(FakeContext(), bioguide_id="ZZZ999")
+    assert isinstance(out, str)
+    assert "DATA_NOT_FOUND" in out
+    assert "experiencing issues" not in out and "SERVER_ERROR" not in out
+
+
+@pytest.mark.asyncio
+async def test_get_bill_details_reports_not_found():
+    from congress_api.features.buckets.bills import api as mod
+    from congress_api.core import api_wrapper
+    with patch.object(api_wrapper, "make_api_request", AsyncMock(return_value=_api_error(404))):
+        out = await mod.get_bill_details(FakeContext(), congress=119, bill_type="hr",
+                                         bill_number=9999999)
+    assert isinstance(out, str)
+    assert "DATA_NOT_FOUND" in out
+    assert "experiencing issues" not in out
+
+
+@pytest.mark.asyncio
+async def test_get_treaty_detail_reports_not_found():
+    from congress_api.features import treaties as mod
+    from congress_api.core import api_wrapper
+    with patch.object(api_wrapper, "make_api_request", AsyncMock(return_value=_api_error(404))):
+        out = await mod.get_treaty_detail(FakeContext(), congress=118, treaty_number=99999)
+    assert isinstance(out, str)
+    assert "DATA_NOT_FOUND" in out and "SERVER_ERROR" not in out
+
+
+# ---------------------------------------------------------------------------
+# static guard
+# ---------------------------------------------------------------------------
+
+def _handler_modules():
+    root = os.path.join(os.path.dirname(os.path.dirname(__file__)), "congress_api", "features")
+    files = glob.glob(os.path.join(root, "*.py")) + [
+        os.path.join(root, "buckets", "bills", "api.py"),
+        os.path.join(root, "buckets", "amendments", "api.py"),
+    ]
+    for f in files:
+        src = open(f).read()
+        if "return format_error_response" in src and "raise ToolError" not in src:
+            yield f, src
+
+
+def test_every_generic_except_that_formats_errors_has_typed_clause_first():
+    """In handler modules, `except Exception as e:` blocks that return a
+    formatted error must be preceded by `except CongressionalAPIError`, else a
+    typed 404 gets re-wrapped as SERVER_ERROR again."""
+    offenders = []
+    for f, src in _handler_modules():
+        lines = src.split("\n")
+        for i, line in enumerate(lines):
+            if re.match(r"^\s*except Exception as e:\s*$", line):
+                window = "\n".join(lines[i + 1:i + 9])
+                if "format_error_response(" not in window:
+                    continue
+                prev = "\n".join(lines[max(0, i - 2):i])
+                if "except CongressionalAPIError" not in prev:
+                    offenders.append(f"{os.path.relpath(f)}:{i + 1}")
+    assert offenders == []

--- a/tests/test_typed_api_errors.py
+++ b/tests/test_typed_api_errors.py
@@ -143,7 +143,7 @@ def test_every_generic_except_that_formats_errors_has_typed_clause_first():
         lines = src.split("\n")
         for i, line in enumerate(lines):
             if re.match(r"^\s*except Exception as e:\s*$", line):
-                window = "\n".join(lines[i + 1:i + 9])
+                window = "\n".join(lines[i + 1:i + 14])
                 if "format_error_response(" not in window:
                     continue
                 prev = "\n".join(lines[max(0, i - 2):i])


### PR DESCRIPTION
Second batch from the [functional review](https://github.com/amurshak/congressMcpFiles/blob/master/docs/reviews/2026-08-21-functional-review.md). **Stacked on #60** (base branch `fix/review-p1-batch`); GitHub will retarget to `master` when #60 merges.

## Problem
`DefensiveAPIWrapper` mapped a 404 to `DATA_NOT_FOUND` correctly, then discarded the type with `raise Exception(message)`. Every handler's `except Exception` re-wrapped the string as `api_server_error`, so `get_bill_details(119, hr, 9999999)`, `get_member_details("ZZZ999")`, `search_crs_reports(report_number="R47234")` etc. all told the model *"The Congressional API is experiencing issues… try again in a few minutes"* — which makes an LLM retry instead of fixing the identifier.

## Fix
1. **Wrapper** raises the existing typed `CongressionalAPIError(error_response)`; the not-found message now names the endpoint and says retrying won't help. 404/400 still short-circuit retries.
2. **Handlers** (mechanical, scripted): `except CongressionalAPIError as e: return format_error_response(e.error_response)` inserted ahead of each generic `except Exception as e:` that returns a formatted error — 103 sites in 22 handler modules. Bucket routers (which must raise `ToolError`), formatters, and dict/list-returning helpers were deliberately left alone.
3. `fetch_bill_data` (bills helper) had its own generic except; it now passes the typed error through.

## Verification
- `tests/test_typed_api_errors.py` (8 tests): wrapper classification for 404/400/5xx, no retry on 404, three representative handlers, and a static guard that every formatted-error `except Exception` in a handler module is preceded by the typed clause.
- `test_invoke_all_operations_with_defaults` + `check_known_failures` + `audit_tool_schemas --check` unchanged vs base.
- No touched file has more ruff errors than before.
- Live over stdio: bad bill / bad member / bad CRS number / bad treaty → `DATA_NOT_FOUND` with the endpoint named; HR 1 and S000148 lookups unchanged.

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)