### PR TITLE
Quiet local defaults: WARNING logging, no PORT heuristic, .env never overrides the shell (#57)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,9 @@
 
 # API Configuration
 CONGRESS_API_KEY=your_congress_api_key_here
-CONGRESS_API_ENV=development
+# CONGRESS_API_ENV selects a .env.{name} file (development/staging/production).
+# Export it in your shell if needed -- setting it inside this file has no effect
+# on which file gets loaded.
 CONGRESS_API_BASE_URL=https://api.congress.gov/v3
 ENABLE_CACHING=false
 CACHE_TIMEOUT=300

--- a/README.md
+++ b/README.md
@@ -485,6 +485,8 @@ Point a client at a source checkout by using `"command": "congressmcp"` (with th
 | `GOVINFO_API_KEY` | No | — | Optional override for GovInfo; otherwise `CONGRESS_API_KEY` is reused |
 | `ENABLE_CACHING` | No | `false` | Cache API responses in memory |
 | `CACHE_TIMEOUT` | No | `300` | Cache TTL in seconds |
+| `LOG_LEVEL` | No | `WARNING` | Logging verbosity on stderr (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `CONGRESS_API_ENV` | No | `local` | Set to `development`/`staging`/`production` to load the matching `.env.*` file; unset loads only a plain `.env`. Files never override exported variables |
 | `CONGRESSMCP_BILL_TEXT_ONLY` | No | unset | If truthy, register only the three bill-text tools (standalone bill-text server) |
 | `CONGRESSMCP_TRACE_DIR` | No | unset | If set to a directory, write one key-redacted JSONL record per bill-text tool call (debugging) |
 | `CONGRESSMCP_CACHE_DIR` | No | Platform cache path | Bill-text package cache root (persistent cache is planned; currently in-memory) |

--- a/congress_api/core/api_config.py
+++ b/congress_api/core/api_config.py
@@ -11,53 +11,33 @@ logger = logging.getLogger(__name__)
 
 def load_environment_config():
     """
-    Load environment variables from the appropriate .env file.
-    
-    Priority:
-    1. CONGRESS_API_ENV environment variable (development, production, staging)
-    2. Heroku detection (if PORT is set, assume production)
-    3. Default to development
+    Load environment variables from a .env file, without overriding the shell.
+
+    Rules:
+    - CONGRESS_API_ENV selects an explicit environment ("production",
+      "staging", "development"): its .env.{env} file is loaded if present.
+    - Unset (the normal end-user install): environment is "local" and only a
+      plain .env at the project root is loaded, if one exists.
+    - Files never override variables already exported in the environment
+      (override=False), so `CONGRESS_API_KEY=... congressmcp` always wins.
+    - No platform auto-detection: the old Heroku PORT heuristic is gone.
     """
-    # Get the project root directory
     project_root = Path(__file__).parent.parent.parent
-    
-    # Determine environment
-    env = os.getenv('CONGRESS_API_ENV')
-    
-    if not env:
-        # Auto-detect environment
-        if os.getenv('PORT'):  # Heroku sets PORT
-            env = 'production'
-        else:
-            env = 'development'
-    
-    env = env.lower()
-    
-    # Load the appropriate .env file
-    if env == "production":
-        # In production, we expect environment variables to be set by the deployment platform
-        # But we can still try to load from .env.production as a fallback
-        env_file = project_root / ".env.production"
+
+    env = (os.getenv('CONGRESS_API_ENV') or '').lower().strip()
+
+    if env:
+        env_file = project_root / f".env.{env}"
         if env_file.exists():
-            logger.info(f"Loading production environment from: {env_file}")
-            load_dotenv(env_file, override=True)
-    elif env == "staging":
-        env_file = project_root / ".env.staging"
+            logger.info(f"Loading {env} environment from: {env_file}")
+            load_dotenv(env_file, override=False)
+    else:
+        env = 'local'
+        env_file = project_root / ".env"
         if env_file.exists():
-            logger.info(f"Loading staging environment from: {env_file}")
-            load_dotenv(env_file, override=True)
-    else:  # development is the default
-        env_file = project_root / ".env.development"
-        if env_file.exists():
-            logger.info(f"Loading development environment from: {env_file}")
-            load_dotenv(env_file, override=True)
-        else:
-            # Fallback to .env
-            fallback_env = project_root / ".env"
-            if fallback_env.exists():
-                logger.info(f"Fallback: Loading environment from: {fallback_env}")
-                load_dotenv(fallback_env, override=True)
-    
+            logger.info(f"Loading environment from: {env_file}")
+            load_dotenv(env_file, override=False)
+
     logger.info(f"Environment: {env}")
     return env
 

--- a/congress_api/core/api_config.py
+++ b/congress_api/core/api_config.py
@@ -4,7 +4,7 @@ import sys
 import logging
 from pathlib import Path
 from dotenv import load_dotenv
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -25,6 +25,12 @@ def load_environment_config():
     project_root = Path(__file__).parent.parent.parent
 
     env = (os.getenv('CONGRESS_API_ENV') or '').lower().strip()
+
+    if env and env not in ('development', 'staging', 'production'):
+        logger.warning(
+            f"Unknown CONGRESS_API_ENV '{env}' (expected development, staging"
+            f" or production); treating as 'local'.")
+        env = ''
 
     if env:
         env_file = project_root / f".env.{env}"

--- a/congress_api/main.py
+++ b/congress_api/main.py
@@ -39,13 +39,14 @@ class SensitiveInfoFilter(logging.Filter):
 def setup_logging():
     """Configure logging for the application based on environment with security considerations."""
 
-    # Determine log level based on environment
-    if ENV == "production":
+    # Determine log level based on environment. Local (end-user) installs
+    # default to WARNING: an MCP server's stderr lands in the client's logs,
+    # and DEBUG streamed full httpx wire traffic there. Set LOG_LEVEL to
+    # override (e.g. LOG_LEVEL=DEBUG for development).
+    if ENV in ("production", "staging"):
         default_level = logging.INFO
-    elif ENV == "staging":
-        default_level = logging.INFO
-    else:  # development
-        default_level = logging.DEBUG
+    else:  # local / development
+        default_level = logging.WARNING
 
     # Allow override via environment variable
     log_level_name = os.getenv("LOG_LEVEL", "")

--- a/tests/test_env_logging_defaults.py
+++ b/tests/test_env_logging_defaults.py
@@ -105,7 +105,7 @@ def _restore_logging():
         logging.getLogger(n).setLevel(level)
 
 
-def _setup_with(env_name, log_level_var, _restore):
+def _setup_with(env_name, log_level_var):
     with patch.object(main_mod, "ENV", env_name), \
             patch.dict(os.environ, {"LOG_LEVEL": log_level_var} if log_level_var else {},
                        clear=False):
@@ -116,13 +116,19 @@ def _setup_with(env_name, log_level_var, _restore):
 
 
 def test_local_defaults_to_warning(_restore_logging):
-    assert _setup_with("local", None, _restore_logging) == logging.WARNING
+    assert _setup_with("local", None) == logging.WARNING
 
 
 def test_production_defaults_to_info(_restore_logging):
-    assert _setup_with("production", None, _restore_logging) == logging.INFO
+    assert _setup_with("production", None) == logging.INFO
 
 
 def test_log_level_env_var_still_overrides(_restore_logging):
-    assert _setup_with("local", "DEBUG", _restore_logging) == logging.DEBUG
-    assert _setup_with("production", "ERROR", _restore_logging) == logging.ERROR
+    assert _setup_with("local", "DEBUG") == logging.DEBUG
+    assert _setup_with("production", "ERROR") == logging.ERROR
+
+
+def test_unknown_congress_api_env_falls_back_to_local():
+    env, calls = _run_load({"CONGRESS_API_ENV": "prod"}, {".env.prod", ".env"})
+    assert env == "local"          # typo warned about, not silently honored
+    assert (".env.prod", False) not in calls

--- a/tests/test_env_logging_defaults.py
+++ b/tests/test_env_logging_defaults.py
@@ -1,0 +1,128 @@
+"""Issue #57: SaaS-era defaults.
+
+- No CONGRESS_API_ENV => environment is "local"; the old Heroku PORT
+  heuristic must not flip a laptop into "production".
+- .env files never override exported shell variables (override=False).
+- Default log level is WARNING for local installs (INFO for
+  production/staging); LOG_LEVEL still overrides.
+"""
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import patch
+
+from congress_api.core import api_config
+from congress_api import main as main_mod
+
+
+# ---------------------------------------------------------------------------
+# load_environment_config
+# ---------------------------------------------------------------------------
+
+def _run_load(env_vars, existing_files):
+    """Run load_environment_config with a controlled environment.
+
+    existing_files: set of file names (e.g. {".env"}) that Path.exists
+    should report as present. Returns (env, load_dotenv_calls).
+    """
+    calls = []
+
+    def fake_load_dotenv(path, override=None, **kw):
+        calls.append((os.path.basename(str(path)), override))
+        return True
+
+    real_exists = api_config.Path.exists
+
+    def fake_exists(self):
+        if self.name.startswith(".env"):
+            return self.name in existing_files
+        return real_exists(self)
+
+    with patch.dict(os.environ, env_vars, clear=False), \
+            patch.object(api_config, "load_dotenv", fake_load_dotenv), \
+            patch.object(api_config.Path, "exists", fake_exists):
+        for var in ("CONGRESS_API_ENV", "PORT"):
+            if var not in env_vars:
+                os.environ.pop(var, None)
+        env = api_config.load_environment_config()
+    return env, calls
+
+
+def test_default_env_is_local_and_ignores_port():
+    env, calls = _run_load({"PORT": "8000"}, {".env"})
+    assert env == "local"          # PORT no longer implies production
+    assert calls == [(".env", False)]
+
+
+def test_no_env_files_is_fine():
+    env, calls = _run_load({}, set())
+    assert env == "local"
+    assert calls == []
+
+
+def test_explicit_env_loads_matching_file_without_override():
+    env, calls = _run_load({"CONGRESS_API_ENV": "production"},
+                           {".env.production"})
+    assert env == "production"
+    assert calls == [(".env.production", False)]
+
+
+def test_env_files_never_override_shell():
+    """Whatever branch runs, every load_dotenv call must pass override=False."""
+    for env_vars, files in [({}, {".env"}),
+                            ({"CONGRESS_API_ENV": "development"}, {".env.development"}),
+                            ({"CONGRESS_API_ENV": "staging"}, {".env.staging"})]:
+        _env, calls = _run_load(env_vars, files)
+        assert calls, (env_vars, files)
+        assert all(override is False for _f, override in calls)
+
+
+def test_dev_file_not_loaded_implicitly():
+    """.env.development must require an explicit CONGRESS_API_ENV opt-in."""
+    _env, calls = _run_load({}, {".env.development", ".env"})
+    assert (".env.development", False) not in calls
+    assert calls == [(".env", False)]
+
+
+# ---------------------------------------------------------------------------
+# setup_logging defaults
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def _restore_logging():
+    root = logging.getLogger()
+    saved_level, saved_handlers = root.level, list(root.handlers)
+    saved = {n: logging.getLogger(n).level
+             for n in ("congress_api", "congress_api.features", "httpx", "uvicorn")}
+    yield
+    root.setLevel(saved_level)
+    root.handlers = saved_handlers
+    for n, level in saved.items():
+        logging.getLogger(n).setLevel(level)
+
+
+def _setup_with(env_name, log_level_var, _restore):
+    with patch.object(main_mod, "ENV", env_name), \
+            patch.dict(os.environ, {"LOG_LEVEL": log_level_var} if log_level_var else {},
+                       clear=False):
+        if not log_level_var:
+            os.environ.pop("LOG_LEVEL", None)
+        main_mod.setup_logging()
+    return logging.getLogger().level
+
+
+def test_local_defaults_to_warning(_restore_logging):
+    assert _setup_with("local", None, _restore_logging) == logging.WARNING
+
+
+def test_production_defaults_to_info(_restore_logging):
+    assert _setup_with("production", None, _restore_logging) == logging.INFO
+
+
+def test_log_level_env_var_still_overrides(_restore_logging):
+    assert _setup_with("local", "DEBUG", _restore_logging) == logging.DEBUG
+    assert _setup_with("production", "ERROR", _restore_logging) == logging.ERROR


### PR DESCRIPTION
Fixes the two SaaS-era defaults from the functional review's P3-1/P3-2 ([#57](https://github.com/amurshak/congressMCP/issues/57)).

## What changed
- **Default environment is now `local`** (was `development`, or `production` whenever Heroku's `PORT` env var happened to be set). Root log level for local installs drops **DEBUG → WARNING**, so `uvx congressmcp` no longer streams full httpx wire logs (incl. response `Set-Cookie` headers) into the MCP client's stderr. `LOG_LEVEL` still overrides; production/staging keep INFO.
- **Env files never override the shell**: `load_dotenv(..., override=False)` everywhere, `.env.development` loads only with an explicit `CONGRESS_API_ENV=development`, and the default path loads only a plain `.env`. `CONGRESS_API_KEY=... congressmcp` now always wins over any file.
- README: `LOG_LEVEL` and `CONGRESS_API_ENV` documented in the Configuration table.

## Verification
- `tests/test_env_logging_defaults.py` (8 tests): PORT is ignored, `.env.development` needs the opt-in, every `load_dotenv` call passes `override=False`, WARNING/INFO defaults, `LOG_LEVEL` override.
- Live over stdio: a `laws` tool call at default settings writes **0 stderr lines** (previously hundreds of DEBUG lines); an exported `CONGRESS_API_KEY=SHELLWINS` beats the repo's `.env`.
- `check_known_failures` + schema audit unchanged; ruff on `api_config.py` improved 7 → 1.

Closes #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)