### PR TITLE
Populate structured responses with real data; results_count = len(items) (#55)

### DIFF
--- a/congress_api/features/bound_congressional_record.py
+++ b/congress_api/features/bound_congressional_record.py
@@ -15,6 +15,7 @@ from ..core.api_wrapper import safe_congressional_request
 from ..core.exceptions import handle_validation_error, format_error_response, CommonErrors, CongressionalAPIError
 from ..core.response_utils import clean_bound_congressional_record_response
 from ..mcp_app import mcp
+from ..utils.structured import structured
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -336,7 +337,7 @@ async def search_bound_congressional_record(
         result += ".\n\n"
         result += "\n".join(formatted_results)
         
-        return result
+        return structured(result, "bound_record", deduplicated_issues)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)

--- a/congress_api/features/buckets/committee_intelligence.py
+++ b/congress_api/features/buckets/committee_intelligence.py
@@ -13,81 +13,46 @@ from ...core.exceptions import CongressionalAPIError
 from ...mcp_app import mcp
 from ...core.operation_routing import validate_operation_kwargs
 from ...models.responses import CommitteeIntelligenceResponse, CommitteeActivitySummary
-from ...utils.response_converters import _extract_result_count, _extract_json
+from ...utils.response_converters import _extract_result_count, structured_items_of
 
 logger = logging.getLogger(__name__)
 
 def _convert_to_structured_response(raw_response: str, operation: str) -> CommitteeIntelligenceResponse:
-    """Convert raw string response to structured CommitteeIntelligenceResponse."""
+    """Build the structured response; typed lists come from the impl's real items."""
     try:
-        if isinstance(raw_response, str):
-            data = _extract_json(raw_response)
-            if data is None:
-                # The underlying impls return pre-formatted markdown, not JSON, so this
-                # is the normal path for every operation, not a fallback for malformed
-                # data — it must preserve the full response, not truncate it.
-                return CommitteeIntelligenceResponse(
-                    success=True,
-                    operation=operation,
-                    results_count=_extract_result_count(raw_response),
-                    activities=[],
-                    summary=raw_response,
-                    insights=[]
-                )
-        else:
-            data = raw_response
-
-        activities = []
-        results_count = 0
-
-        if isinstance(data, dict):
-            # Handle committee activities
-            if 'activities' in data:
-                for activity_data in data.get('activities', []):
-                    if isinstance(activity_data, dict):
-                        activities.append(CommitteeActivitySummary(
-                            committee_name=activity_data.get('committee', ''),
-                            activity_type=activity_data.get('activityType', ''),
-                            title=activity_data.get('title', ''),
-                            date=activity_data.get('date'),
-                            status=activity_data.get('status', ''),
-                            url=activity_data.get('url')
-                        ))
-
-            # Handle meetings as activities
-            if 'meetings' in data:
-                for meeting_data in data.get('meetings', []):
-                    if isinstance(meeting_data, dict):
-                        activities.append(CommitteeActivitySummary(
-                            committee_name=meeting_data.get('committee', ''),
-                            activity_type='meeting',
-                            title=meeting_data.get('title', ''),
-                            date=meeting_data.get('date'),
-                            status=meeting_data.get('status', ''),
-                            url=meeting_data.get('url')
-                        ))
-
-            results_count = len(activities)
+        kind, items = structured_items_of(raw_response)
+        if items is not None:
+            activities = []
+            kind_map = {"committee_report": "report", "committee_print": "print",
+                        "committee_meeting": "meeting"}
+            activity_type = kind_map.get(kind or "", kind or "activity")
+            for a in items:
+                identifier = a.get("number") or a.get("jacketNumber") or a.get("eventId")
+                activities.append(CommitteeActivitySummary(
+                    activity_type=activity_type,
+                    citation=a.get("citation"),
+                    identifier=str(identifier) if identifier is not None else None,
+                    congress=a.get("congress"),
+                    chamber=a.get("chamber"),
+                    committee_name=(a.get("committees") or [{}])[0].get("name")
+                    if isinstance(a.get("committees"), list) else None,
+                    title=a.get("title"),
+                    date=a.get("updateDate") or a.get("date"),
+                    url=a.get("url"),
+                ))
+            return CommitteeIntelligenceResponse(
+                success=True, operation=operation, results_count=len(items),
+                activities=activities, summary=str(raw_response))
 
         return CommitteeIntelligenceResponse(
-            success=True,
-            operation=operation,
-            results_count=results_count,
-            activities=activities,
-            summary=f"Found {len(activities)} committee activities",
-            insights=[]
-        )
-
+            success=True, operation=operation,
+            results_count=_extract_result_count(raw_response),
+            activities=[], summary=str(raw_response))
     except Exception as e:
         logger.error(f"Error converting response to structured format: {e}")
         return CommitteeIntelligenceResponse(
-            success=False,
-            operation=operation,
-            results_count=0,
-            activities=[],
-            summary=f"Error processing response: {str(e)}",
-            insights=[]
-        )
+            success=False, operation=operation, results_count=0,
+            activities=[], summary=f"Error processing response: {str(e)}")
 
 async def route_committee_intelligence_operation(ctx: Context, operation: str, **kwargs) -> CommitteeIntelligenceResponse:
     """Route operation to appropriate internal function."""

--- a/congress_api/features/buckets/records_and_hearings.py
+++ b/congress_api/features/buckets/records_and_hearings.py
@@ -13,7 +13,7 @@ from ...core.exceptions import CongressionalAPIError
 from ...mcp_app import mcp
 from ...core.operation_routing import validate_operation_kwargs
 from ...models.responses import RecordsHearingsResponse, HearingSummary, RecordSummary
-from ...utils.response_converters import _extract_result_count, structured_items_of
+from ...utils.response_converters import _extract_result_count, _int_or_none, structured_items_of
 
 logger = logging.getLogger(__name__)
 
@@ -39,10 +39,10 @@ def _convert_to_structured_response(raw_response: str, operation: str) -> Record
             elif kind in ("record", "daily_record", "bound_record"):
                 for r in items:
                     records.append(RecordSummary(
-                        volume=_int(r.get("Volume") or r.get("volumeNumber") or r.get("volume")),
-                        issue=_int(r.get("Issue") or r.get("issueNumber")),
-                        session=_int(r.get("Session") or r.get("sessionNumber")),
-                        congress=_int(r.get("Congress") or r.get("congress")),
+                        volume=_int_or_none(r.get("Volume") or r.get("volumeNumber") or r.get("volume")),
+                        issue=_int_or_none(r.get("Issue") or r.get("issueNumber")),
+                        session=_int_or_none(r.get("Session") or r.get("sessionNumber")),
+                        congress=_int_or_none(r.get("Congress") or r.get("congress")),
                         date=r.get("PublishDate") or r.get("issueDate") or r.get("date"),
                         id=str(r.get("Id")) if r.get("Id") is not None else None,
                         url=r.get("url"),
@@ -64,12 +64,6 @@ def _convert_to_structured_response(raw_response: str, operation: str) -> Record
             success=False, operation=operation, results_count=0,
             hearings=[], records=[], summary=f"Error processing response: {str(e)}")
 
-
-def _int(value):
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
 
 async def route_records_and_hearings_operation(ctx: Context, operation: str, **kwargs) -> RecordsHearingsResponse:
     """Route operation to appropriate internal function."""

--- a/congress_api/features/buckets/records_and_hearings.py
+++ b/congress_api/features/buckets/records_and_hearings.py
@@ -196,7 +196,7 @@ async def records_and_hearings(
     CONGRESSIONAL RECORDS (3 operations):
     • search_congressional_record/daily/bound - Search legislative records by date/volume
 
-    COMMUNICATIONS (8 operations):  
+    COMMUNICATIONS (8 operations):
     • House: search_house_communications/requirements, get_details/matching
     • Senate: search_senate_communications, get_senate_communication_details
     • Committee: get_committee_communication_details

--- a/congress_api/features/buckets/records_and_hearings.py
+++ b/congress_api/features/buckets/records_and_hearings.py
@@ -13,83 +13,63 @@ from ...core.exceptions import CongressionalAPIError
 from ...mcp_app import mcp
 from ...core.operation_routing import validate_operation_kwargs
 from ...models.responses import RecordsHearingsResponse, HearingSummary, RecordSummary
-from ...utils.response_converters import _extract_result_count, _extract_json
+from ...utils.response_converters import _extract_result_count, structured_items_of
 
 logger = logging.getLogger(__name__)
 
 def _convert_to_structured_response(raw_response: str, operation: str) -> RecordsHearingsResponse:
-    """Convert raw string response to structured RecordsHearingsResponse."""
+    """Build the structured response; typed lists come from the impl's real items."""
     try:
-        if isinstance(raw_response, str):
-            data = _extract_json(raw_response)
-            if data is None:
-                # The underlying impls return pre-formatted markdown, not JSON, so this
-                # is the normal path for every operation, not a fallback for malformed
-                # data — it must preserve the full response, not truncate it.
-                return RecordsHearingsResponse(
-                    success=True,
-                    operation=operation,
-                    results_count=_extract_result_count(raw_response),
-                    hearings=[],
-                    records=[],
-                    summary=raw_response
-                )
-        else:
-            data = raw_response
-
-        hearings = []
-        records = []
-        results_count = 0
-
-        if isinstance(data, dict):
-            # Handle hearings
-            if 'hearings' in data:
-                for hearing_data in data.get('hearings', []):
-                    if isinstance(hearing_data, dict):
-                        hearings.append(HearingSummary(
-                            congress=hearing_data.get('congress', 0),
-                            chamber=hearing_data.get('chamber', ''),
-                            jacket_number=hearing_data.get('jacketNumber', ''),
-                            title=hearing_data.get('title', ''),
-                            committee=hearing_data.get('committee', ''),
-                            date=hearing_data.get('date'),
-                            url=hearing_data.get('url')
-                        ))
-
-            # Handle congressional records
-            if 'records' in data:
-                for record_data in data.get('records', []):
-                    if isinstance(record_data, dict):
-                        records.append(RecordSummary(
-                            volume=record_data.get('volume', 0),
-                            issue=record_data.get('issue', 0),
-                            date=record_data.get('date', ''),
-                            section=record_data.get('section', ''),
-                            title=record_data.get('title', ''),
-                            url=record_data.get('url')
-                        ))
-
-            results_count = len(hearings) + len(records)
+        kind, items = structured_items_of(raw_response)
+        if items is not None:
+            hearings, records, generic = [], [], []
+            if kind == "hearing":
+                for h in items:
+                    hearings.append(HearingSummary(
+                        jacket_number=str(h.get("jacketNumber", "")),
+                        congress=h.get("congress"),
+                        chamber=h.get("chamber"),
+                        title=h.get("title"),
+                        committee=(h.get("committees") or [{}])[0].get("name")
+                        if isinstance(h.get("committees"), list) else None,
+                        date=(h.get("dates") or [{}])[0].get("date") if isinstance(h.get("dates"), list) else None,
+                        update_date=h.get("updateDate"),
+                        url=h.get("url"),
+                    ))
+            elif kind in ("record", "daily_record", "bound_record"):
+                for r in items:
+                    records.append(RecordSummary(
+                        volume=_int(r.get("Volume") or r.get("volumeNumber") or r.get("volume")),
+                        issue=_int(r.get("Issue") or r.get("issueNumber")),
+                        session=_int(r.get("Session") or r.get("sessionNumber")),
+                        congress=_int(r.get("Congress") or r.get("congress")),
+                        date=r.get("PublishDate") or r.get("issueDate") or r.get("date"),
+                        id=str(r.get("Id")) if r.get("Id") is not None else None,
+                        url=r.get("url"),
+                    ))
+            else:
+                generic = items
+            return RecordsHearingsResponse(
+                success=True, operation=operation, results_count=len(items),
+                hearings=hearings, records=records, items=generic,
+                item_kind=kind, summary=str(raw_response))
 
         return RecordsHearingsResponse(
-            success=True,
-            operation=operation,
-            results_count=results_count,
-            hearings=hearings,
-            records=records,
-            summary=f"Found {len(hearings)} hearings and {len(records)} records"
-        )
-
+            success=True, operation=operation,
+            results_count=_extract_result_count(raw_response),
+            hearings=[], records=[], summary=str(raw_response))
     except Exception as e:
         logger.error(f"Error converting response to structured format: {e}")
         return RecordsHearingsResponse(
-            success=False,
-            operation=operation,
-            results_count=0,
-            hearings=[],
-            records=[],
-            summary=f"Error processing response: {str(e)}"
-        )
+            success=False, operation=operation, results_count=0,
+            hearings=[], records=[], summary=f"Error processing response: {str(e)}")
+
+
+def _int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 async def route_records_and_hearings_operation(ctx: Context, operation: str, **kwargs) -> RecordsHearingsResponse:
     """Route operation to appropriate internal function."""

--- a/congress_api/features/buckets/research_and_professional.py
+++ b/congress_api/features/buckets/research_and_professional.py
@@ -13,81 +13,43 @@ from ...core.exceptions import CongressionalAPIError
 from ...mcp_app import mcp
 from ...core.operation_routing import validate_operation_kwargs
 from ...models.responses import ResearchProfessionalResponse, ResearchSummary
-from ...utils.response_converters import _extract_result_count, _extract_json
+from ...utils.response_converters import _extract_result_count, structured_items_of
 
 logger = logging.getLogger(__name__)
 
 def _convert_to_structured_response(raw_response: str, operation: str) -> ResearchProfessionalResponse:
-    """Convert raw string response to structured ResearchProfessionalResponse."""
+    """Build the structured response; typed lists come from the impl's real items."""
     try:
-        if isinstance(raw_response, str):
-            data = _extract_json(raw_response)
-            if data is None:
-                # The underlying impls return pre-formatted markdown, not JSON, so this
-                # is the normal path for every operation, not a fallback for malformed
-                # data — it must preserve the full response, not truncate it.
-                return ResearchProfessionalResponse(
-                    success=True,
-                    operation=operation,
-                    results_count=_extract_result_count(raw_response),
-                    research_materials=[],
-                    summary=raw_response,
-                    recommended_reading=[]
-                )
-        else:
-            data = raw_response
-
-        research_materials = []
-        results_count = 0
-
-        if isinstance(data, dict):
-            # Handle research materials (CRS reports, committee reports, etc.)
-            if 'reports' in data:
-                for report_data in data.get('reports', []):
-                    if isinstance(report_data, dict):
-                        research_materials.append(ResearchSummary(
-                            title=report_data.get('title', ''),
-                            type=report_data.get('reportType', 'Research Document'),
-                            date=report_data.get('date'),
-                            summary=report_data.get('summary'),
-                            topics=report_data.get('policyArea', []),
-                            url=report_data.get('url')
-                        ))
-
-            # Handle other research document types
-            if 'crsReports' in data:
-                for crs_data in data.get('crsReports', []):
-                    if isinstance(crs_data, dict):
-                        research_materials.append(ResearchSummary(
-                            title=crs_data.get('title', ''),
-                            type='CRS Report',
-                            date=crs_data.get('date'),
-                            summary=crs_data.get('summary'),
-                            topics=crs_data.get('topics', []),
-                            url=crs_data.get('url')
-                        ))
-
-            results_count = len(research_materials)
+        kind, items = structured_items_of(raw_response)
+        if items is not None:
+            materials = []
+            for m in items:
+                if kind == "congress":
+                    start = m.get("startYear")
+                    end = m.get("endYear")
+                    materials.append(ResearchSummary(
+                        title=m.get("name", ""), type="Congress",
+                        date=f"{start}-{end}" if start else None,
+                        url=m.get("url")))
+                else:
+                    materials.append(ResearchSummary(
+                        title=m.get("title", ""), type="CRS Report",
+                        date=m.get("publishDate") or m.get("updateDate"),
+                        status=m.get("status"),
+                        url=m.get("url")))
+            return ResearchProfessionalResponse(
+                success=True, operation=operation, results_count=len(items),
+                research_materials=materials, summary=str(raw_response))
 
         return ResearchProfessionalResponse(
-            success=True,
-            operation=operation,
-            results_count=results_count,
-            research_materials=research_materials,
-            summary=f"Found {len(research_materials)} research materials",
-            recommended_reading=[]
-        )
-
+            success=True, operation=operation,
+            results_count=_extract_result_count(raw_response),
+            research_materials=[], summary=str(raw_response))
     except Exception as e:
         logger.error(f"Error converting response to structured format: {e}")
         return ResearchProfessionalResponse(
-            success=False,
-            operation=operation,
-            results_count=0,
-            research_materials=[],
-            summary=f"Error processing response: {str(e)}",
-            recommended_reading=[]
-        )
+            success=False, operation=operation, results_count=0,
+            research_materials=[], summary=f"Error processing response: {str(e)}")
 
 async def route_research_and_professional_operation(ctx: Context, operation: str, **kwargs) -> ResearchProfessionalResponse:
     """Route operation to appropriate internal function."""

--- a/congress_api/features/buckets/voting_and_nominations.py
+++ b/congress_api/features/buckets/voting_and_nominations.py
@@ -13,85 +13,66 @@ from ...core.exceptions import CongressionalAPIError
 from ...mcp_app import mcp
 from ...core.operation_routing import validate_operation_kwargs
 from ...models.responses import VotingNominationsResponse, VoteSummary, NominationSummary
-from ...utils.response_converters import _extract_result_count, _extract_json
+from ...utils.response_converters import _extract_result_count, structured_items_of
 
 logger = logging.getLogger(__name__)
 
 def _convert_to_structured_response(raw_response: str, operation: str) -> VotingNominationsResponse:
-    """Convert raw string response to structured VotingNominationsResponse."""
+    """Build the structured response; typed lists come from the impl's real items."""
     try:
-        # Parse the raw response
-        if isinstance(raw_response, str):
-            data = _extract_json(raw_response)
-            if data is None:
-                # The underlying impls return pre-formatted markdown, not JSON, so this
-                # is the normal path for every operation, not a fallback for malformed
-                # data — it must preserve the full response, not truncate it.
-                return VotingNominationsResponse(
-                    success=True,
-                    operation=operation,
-                    results_count=_extract_result_count(raw_response),
-                    votes=[],
-                    nominations=[],
-                    summary=raw_response
-                )
-        else:
-            data = raw_response
-
-        votes = []
-        nominations = []
-        results_count = 0
-
-        if isinstance(data, dict):
-            # Handle votes
-            if 'votes' in data:
-                for vote_data in data.get('votes', []):
-                    if isinstance(vote_data, dict):
-                        votes.append(VoteSummary(
-                            vote_number=vote_data.get('voteNumber', 0),
-                            chamber=vote_data.get('chamber', ''),
-                            date=vote_data.get('date', ''),
-                            description=vote_data.get('question', ''),
-                            result=vote_data.get('result', ''),
-                            vote_counts=vote_data.get('totals', {}),
-                            url=vote_data.get('url')
-                        ))
-
-            # Handle nominations
-            if 'nominations' in data:
-                for nom_data in data.get('nominations', []):
-                    if isinstance(nom_data, dict):
-                        nominations.append(NominationSummary(
-                            nomination_number=nom_data.get('nominationNumber', ''),
-                            nominee=nom_data.get('nominee', ''),
-                            position=nom_data.get('position', ''),
-                            organization=nom_data.get('organization', ''),
-                            received_date=nom_data.get('receivedDate'),
-                            status=nom_data.get('latestAction'),
-                            url=nom_data.get('url')
-                        ))
-
-            results_count = len(votes) + len(nominations)
+        kind, items = structured_items_of(raw_response)
+        if items is not None:
+            votes, nominations = [], []
+            if kind == "house_vote":
+                for v in items:
+                    leg_type = v.get("legislationType") or ""
+                    leg_num = v.get("legislationNumber") or ""
+                    legislation = f"{leg_type} {leg_num}".strip() or None
+                    votes.append(VoteSummary(
+                        vote_number=int(v.get("rollCallNumber") or 0),
+                        congress=v.get("congress"),
+                        session=v.get("sessionNumber"),
+                        chamber="House",
+                        legislation=legislation,
+                        vote_type=v.get("voteType"),
+                        result=v.get("result"),
+                        date=v.get("startDate"),
+                        url=v.get("url"),
+                    ))
+            elif kind == "nomination":
+                for n in items:
+                    latest = n.get("latestAction") or {}
+                    latest_text = latest.get("text") if isinstance(latest, dict) else str(latest)
+                    ntype = n.get("nominationType") or {}
+                    nominees = n.get("nominees")
+                    first = nominees[0] if isinstance(nominees, list) and nominees else {}
+                    nominations.append(NominationSummary(
+                        nomination_number=str(n.get("number", "")),
+                        citation=n.get("citation"),
+                        congress=n.get("congress"),
+                        organization=n.get("organization"),
+                        is_military=ntype.get("isMilitary") if isinstance(ntype, dict) else None,
+                        nominee=(f"{first.get('firstName', '')} {first.get('lastName', '')}".strip()
+                                 or None) if first.get("firstName") else None,
+                        position=first.get("positionTitle") if isinstance(first, dict) else None,
+                        received_date=n.get("receivedDate"),
+                        latest_action=latest_text,
+                        update_date=n.get("updateDate"),
+                        url=n.get("url"),
+                    ))
+            return VotingNominationsResponse(
+                success=True, operation=operation, results_count=len(items),
+                votes=votes, nominations=nominations, summary=str(raw_response))
 
         return VotingNominationsResponse(
-            success=True,
-            operation=operation,
-            results_count=results_count,
-            votes=votes,
-            nominations=nominations,
-            summary=f"Found {len(votes)} votes and {len(nominations)} nominations"
-        )
-
+            success=True, operation=operation,
+            results_count=_extract_result_count(raw_response),
+            votes=[], nominations=[], summary=str(raw_response))
     except Exception as e:
         logger.error(f"Error converting response to structured format: {e}")
         return VotingNominationsResponse(
-            success=False,
-            operation=operation,
-            results_count=0,
-            votes=[],
-            nominations=[],
-            summary=f"Error processing response: {str(e)}"
-        )
+            success=False, operation=operation, results_count=0,
+            votes=[], nominations=[], summary=f"Error processing response: {str(e)}")
 
 async def route_voting_and_nominations_operation(ctx: Context, operation: str, **kwargs) -> VotingNominationsResponse:
     """Route operation to appropriate internal function."""

--- a/congress_api/features/committee_meetings.py
+++ b/congress_api/features/committee_meetings.py
@@ -7,6 +7,7 @@ from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator
 from ..core.response_utils import ResponseProcessor
 from ..core.exceptions import format_error_response, CommonErrors, APIErrorResponse, CongressionalAPIError
+from ..utils.structured import structured
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -146,7 +147,7 @@ async def get_latest_committee_meetings(ctx: Context) -> str:
             lines.append("")
             lines.append(format_committee_meeting_item(meeting_item))
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "committee_meeting", meetings)
     
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -196,7 +197,7 @@ async def get_committee_meetings_by_congress(ctx: Context, congress: int) -> str
             lines.append("")
             lines.append(format_committee_meeting_item(meeting_item))
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "committee_meeting", meetings)
     
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -251,7 +252,7 @@ async def get_committee_meetings_by_congress_and_chamber(ctx: Context, congress:
             lines.append("")
             lines.append(format_committee_meeting_item(meeting_item))
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "committee_meeting", meetings)
     
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -344,7 +345,7 @@ async def get_committee_meeting_details(ctx: Context, congress: int, chamber: st
             return f"No committee meeting found for {congress}/{chamber}/{event_id}."
         
         logger.info(f"Successfully retrieved committee meeting details for {congress}/{chamber}/{event_id}")
-        return format_committee_meeting_detail(meeting_data)
+        return structured(format_committee_meeting_detail(meeting_data), "committee_meeting", [meeting_data])
     
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -444,7 +445,7 @@ async def search_committee_meetings(
             lines.append("")
             lines.append(format_committee_meeting_item(meeting_item))
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "committee_meeting", meetings)
     
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)

--- a/congress_api/features/committee_prints.py
+++ b/congress_api/features/committee_prints.py
@@ -8,6 +8,7 @@ from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator, ValidationResult
 from ..core.exceptions import APIErrorResponse, ErrorType, format_error_response, CommonErrors, CongressionalAPIError
 from ..core.response_utils import CommitteePrintsProcessor, clean_committee_prints_response
+from ..utils.structured import structured
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -112,7 +113,7 @@ async def get_latest_committee_prints(ctx: Context) -> str:
             lines.append("")
             lines.append(format_committee_print_item(print_item))
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "committee_print", processed_prints)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -181,7 +182,7 @@ async def get_committee_prints_by_congress(ctx: Context, congress: int) -> str:
             lines.append("")
             lines.append(format_committee_print_item(print_item))
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "committee_print", processed_prints)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -259,7 +260,7 @@ async def get_committee_prints_by_congress_and_chamber(ctx: Context, congress: i
             lines.append("")
             lines.append(format_committee_print_item(print_item))
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "committee_print", processed_prints)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -356,7 +357,7 @@ async def get_committee_print_details(ctx: Context, congress: int, chamber: str,
                 logger.info(f"Empty committee print list: Congress {congress}, chamber {chamber}, jacket {jacket_number}")
                 return format_error_response(error)
         
-        return format_committee_print_detail(print_item)
+        return structured(format_committee_print_detail(print_item), "committee_print", [print_item])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -548,7 +549,7 @@ async def search_committee_prints(
             lines.append("")
             lines.append(format_committee_print_item(print_item))
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "committee_print", processed_prints)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)

--- a/congress_api/features/committee_reports.py
+++ b/congress_api/features/committee_reports.py
@@ -8,6 +8,7 @@ from ..core.client_handler import make_api_request
 from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator
 from ..core.exceptions import format_error_response, CommonErrors, CongressionalAPIError
+from ..utils.structured import structured
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -111,7 +112,7 @@ async def get_latest_committee_reports(ctx: Context) -> str:
         result = f"# Latest Committee Reports ({len(limited_reports)} found)\n\n"
         result += "\n\n---\n\n".join(formatted_reports)
         
-        return result
+        return structured(result, "committee_report", limited_reports)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -176,7 +177,7 @@ async def get_committee_reports_by_congress(ctx: Context, congress: int) -> str:
         result = f"# Committee Reports for Congress {congress} ({len(limited_reports)} found)\n\n"
         result += "\n\n---\n\n".join(formatted_reports)
         
-        return result
+        return structured(result, "committee_report", limited_reports)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -256,7 +257,7 @@ async def get_committee_reports_by_congress_and_type(
         result = f"# Committee Reports for Congress {congress}, Type {report_type} ({len(limited_reports)} found)\n\n"
         result += "\n\n---\n\n".join(formatted_reports)
         
-        return result
+        return structured(result, "committee_report", limited_reports)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -333,7 +334,7 @@ async def get_committee_report_details(
         
         logger.info(f"Successfully retrieved committee report details for {congress}/{report_type}/{report_number}")
         
-        return format_committee_report_detail(report_item)
+        return structured(format_committee_report_detail(report_item), "committee_report", [report_item])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -536,7 +537,7 @@ async def search_committee_reports(
         result = f"# Committee Reports Search Results ({len(limited_reports)} found)\n\n"
         result += "\n\n---\n\n".join(formatted_reports)
         
-        return result
+        return structured(result, "committee_report", limited_reports)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)

--- a/congress_api/features/committees.py
+++ b/congress_api/features/committees.py
@@ -8,6 +8,7 @@ from ..core.validators import ParameterValidator, ValidationResult
 from ..core.api_wrapper import DefensiveAPIWrapper
 from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
+from ..utils.structured import structured
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -198,7 +199,7 @@ async def get_committee_details(ctx: Context, chamber: str, committee_code: str)
     if "url" in committee:
         result.append(f"\nURL: {committee['url']}")
     
-    return "\n".join(result)
+    return structured("\n".join(result), "committee", [committee])
 
 # Tools (Interactive/Parameterized Functions)
 # - get_committee_bills: Bills with limit parameter
@@ -320,7 +321,7 @@ async def get_committee_bills(
             result.append(f"URL: {url}")
         
         logger.info(f"Successfully retrieved {len(bills)} bills for committee {committee_code}")
-        return "\n".join(result)
+        return structured("\n".join(result), "bill", bills[:limit])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -420,7 +421,7 @@ async def get_committee_reports(
             result.append(f"URL: {url}")
         
         logger.info(f"Successfully retrieved {len(reports)} reports for committee {committee_code}")
-        return "\n".join(result)
+        return structured("\n".join(result), "committee_report", reports[:limit])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -512,7 +513,7 @@ async def get_committee_nominations(
             result.append(f"URL: {url}")
         
         logger.info(f"Successfully retrieved {len(nominations)} nominations for committee {committee_code}")
-        return "\n".join(result)
+        return structured("\n".join(result), "nomination", nominations[:limit])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -626,7 +627,7 @@ async def get_committee_communications(
             result.append(f"URL: {url}")
         
         logger.info(f"Successfully retrieved {len(communications)} communications for committee {committee_code}")
-        return "\n".join(result)
+        return structured("\n".join(result), "communication", communications[:limit])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -719,7 +720,7 @@ async def search_committees(
             result.append("\n" + format_committee_summary(committee))
 
         logger.info(f"Successfully found {len(committees)} committees (search='{keywords}', type='{committee_type}')")
-        return "\n".join(result)
+        return structured("\n".join(result), "committee", committees[:limit])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)

--- a/congress_api/features/congress_info.py
+++ b/congress_api/features/congress_info.py
@@ -10,6 +10,7 @@ from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper
 from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
+from ..utils.structured import structured
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -271,7 +272,7 @@ async def get_congress_info(
                 error = CommonErrors.data_not_found("current Congress", "current")
                 return format_error_response(error)
             
-            return format_congress(congress_data, detailed)
+            return structured(format_congress(congress_data, detailed), "congress", [congress_data])
         elif congress is not None:
             # Get specific Congress
             data = await safe_congress_request(f"/congress/{congress}", ctx)
@@ -283,7 +284,7 @@ async def get_congress_info(
                 error = CommonErrors.data_not_found("Congress", str(congress))
                 return format_error_response(error)
             
-            return format_congress(congress_data, detailed)
+            return structured(format_congress(congress_data, detailed), "congress", [congress_data])
         else:
             # Get list of congresses
             data = await safe_congress_request("/congress", ctx, {"limit": limit})
@@ -301,7 +302,8 @@ async def get_congress_info(
                 key_fields=["number", "name"]
             )
             
-            return format_congresses_list(deduplicated_congresses, format_type)
+            text = format_congresses_list(deduplicated_congresses, format_type)
+            return structured(text, "congress", deduplicated_congresses)
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
     except Exception as e:
@@ -436,12 +438,13 @@ async def search_congresses(
                 
                 result.append(f"| {name} | {start_year} - {end_year} | {sessions_str} |")
             
-            return "\n".join(result)
+            return structured("\n".join(result), "congress", limited_congresses)
         else:
             # Use the existing format_congresses_list function
             formatted_list = format_congresses_list(limited_congresses)
             # Replace the default header with our search header
-            return result_header + formatted_list[formatted_list.find("\n"):]
+            text = result_header + formatted_list[formatted_list.find("\n"):]
+            return structured(text, "congress", limited_congresses)
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
     except Exception as e:

--- a/congress_api/features/congressional_record.py
+++ b/congress_api/features/congressional_record.py
@@ -12,6 +12,7 @@ from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper
 from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
+from ..utils.structured import structured
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -283,7 +284,7 @@ async def search_congressional_record(
             lines.append("")
             lines.append(format_record_issue(issue))
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "record", deduplicated_issues)
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
     except Exception as e:

--- a/congress_api/features/crs_reports.py
+++ b/congress_api/features/crs_reports.py
@@ -8,6 +8,7 @@ from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper
 from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
+from ..utils.structured import structured
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -251,7 +252,8 @@ async def search_crs_reports(
                 return format_error_response(CommonErrors.data_not_found(f"CRS report '{report_number}' not found"))
             
             # Format the response
-            return format_crs_report_detail(data)
+            report = data.get("CRSReport") if isinstance(data, dict) else None
+            return structured(format_crs_report_detail(data), "crs_report", [report] if report else [])
         
         # If no keywords provided, guide user
         if not keywords:
@@ -303,7 +305,8 @@ async def search_crs_reports(
                 for report in deduplicated_reports:
                     formatted_reports.append(format_crs_report_item(report))
                 
-                return f"Search Results - CRS Reports matching '{keywords}':\n\n" + "\n\n".join(formatted_reports)
+                text = f"Search Results - CRS Reports matching '{keywords}':\n\n" + "\n\n".join(formatted_reports)
+                return structured(text, "crs_report", deduplicated_reports)
             else:
                 return format_error_response(CommonErrors.data_not_found(f"No CRS reports found matching keywords: '{keywords}'"))
         else:

--- a/congress_api/features/daily_congressional_record.py
+++ b/congress_api/features/daily_congressional_record.py
@@ -8,6 +8,7 @@ from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper
 from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
+from ..utils.structured import structured
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -175,7 +176,7 @@ async def get_latest_daily_congressional_record() -> str:
             for item in deduplicated_records:
                 formatted_items.append(format_daily_record_item(item))
             
-            return "\n\n".join(formatted_items)
+            return structured("\n\n".join(formatted_items), "daily_record", deduplicated_records)
         else:
             logger.warning("No daily congressional record issues found in API response")
             error_response = CommonErrors.data_not_found(
@@ -355,7 +356,8 @@ async def search_daily_congressional_record(
                     
                     search_desc = f"volume {volume_number}" if volume_number else "your search criteria"
                     result_header = f"Daily Congressional Record Issues matching {search_desc}:\n\n"
-                    return result_header + "\n\n".join(formatted_items)
+                    text = result_header + "\n\n".join(formatted_items)
+                    return structured(text, "daily_record", deduplicated_records)
                 else:
                     search_desc = f"volume {volume_number}" if volume_number else "your search criteria"
                     logger.warning(f"No daily congressional record issues found matching {search_desc}")

--- a/congress_api/features/hearings.py
+++ b/congress_api/features/hearings.py
@@ -8,6 +8,7 @@ from ..core.validators import ParameterValidator, ValidationResult
 from ..core.api_wrapper import DefensiveAPIWrapper
 from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
+from ..utils.structured import structured
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -225,7 +226,7 @@ async def get_hearings_by_congress(ctx: Context, congress: int) -> str:
             lines.append("")
             lines.append(format_hearing_item(HearingsProcessor.clean_hearing_response(hearing_item)))
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "hearing", deduplicated_hearings)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -301,7 +302,7 @@ async def get_hearings_by_congress_and_chamber(ctx: Context, congress: int, cham
             lines.append("")
             lines.append(format_hearing_item(HearingsProcessor.clean_hearing_response(hearing_item)))
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "hearing", deduplicated_hearings)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -382,7 +383,8 @@ async def get_hearing_details(ctx: Context, congress: int, chamber: str, jacket_
             return f"No hearing data found for Congress {congress}, Chamber {chamber}, Jacket Number {jacket_number}."
         
         logger.info(f"Successfully retrieved hearing details for {congress}/{chamber}/{jacket_number}")
-        return format_hearing_detail(HearingsProcessor.clean_hearing_response(hearing_data))
+        cleaned_hearing = HearingsProcessor.clean_hearing_response(hearing_data)
+        return structured(format_hearing_detail(cleaned_hearing), "hearing", [cleaned_hearing])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -613,7 +615,7 @@ async def search_hearings(
             lines.append("")
             lines.append(format_hearing_item(HearingsProcessor.clean_hearing_response(hearing_item)))
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "hearing", deduplicated_hearings)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)

--- a/congress_api/features/house_communications.py
+++ b/congress_api/features/house_communications.py
@@ -10,6 +10,7 @@ from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper
 from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import HouseCommunicationsProcessor
+from ..utils.structured import structured
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -267,7 +268,7 @@ async def get_house_communication_details(
             return f"House communication {congress}/{communication_type}/{communication_number} not found."
         
         logger.info(f"Retrieved details for house communication {congress}/{communication_type}/{communication_number}")
-        return format_house_communication_detail(comm_data)
+        return structured(format_house_communication_detail(comm_data), "communication", [comm_data])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -371,7 +372,7 @@ async def search_house_communications(
             lines.append(format_house_communication_item(comm))
             lines.append("")
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "communication", processed_communications[:limit])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)

--- a/congress_api/features/house_requirements.py
+++ b/congress_api/features/house_requirements.py
@@ -9,6 +9,7 @@ from ..core.validators import ParameterValidator
 from ..core.api_wrapper import DefensiveAPIWrapper
 from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
+from ..utils.structured import structured
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -258,7 +259,7 @@ async def search_house_requirements(
             lines.append(format_house_requirement_item(req))
             lines.append("")
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "requirement", requirements[:limit])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -309,7 +310,7 @@ async def get_house_requirement_details(
             return f"House requirement {requirement_number} not found."
         
         logger.info(f"Found house requirement {requirement_number}")
-        return format_house_requirement_detail(requirement)
+        return structured(format_house_requirement_detail(requirement), "requirement", [requirement])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -351,7 +352,11 @@ async def get_house_requirement_matching_communications(
             return format_error_response(CommonErrors.api_server_error(endpoint, message=data['error']))
         
         logger.info(f"Found matching communications for house requirement {requirement_number}")
-        return format_matching_communications(data)
+        matching = data.get('houseCommunications') or []
+        formatted = format_matching_communications(data)
+        if matching:
+            return structured(formatted, "communication", matching)
+        return formatted
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)

--- a/congress_api/features/house_votes.py
+++ b/congress_api/features/house_votes.py
@@ -12,6 +12,7 @@ from ..core.validators import ParameterValidator, ValidationResult
 from ..core.api_wrapper import safe_congressional_request
 from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
+from ..utils.structured import structured
 
 logger = logging.getLogger(__name__)
 
@@ -431,7 +432,7 @@ async def get_house_votes_by_congress(ctx: Context, congress: int, limit: int = 
             lines.append(f"## {i}. {format_house_vote_summary(vote)}")
             lines.append("")
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "house_vote", votes)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -492,7 +493,7 @@ async def get_house_votes_by_session(ctx: Context, congress: int, session: int, 
             lines.append(f"## {i}. {format_house_vote_summary(vote)}")
             lines.append("")
         
-        return "\n".join(lines)
+        return structured("\n".join(lines), "house_vote", votes)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -544,7 +545,8 @@ async def get_house_vote_details(ctx: Context, congress: int, session: int, vote
             return f"House vote {congress}-{session}-{vote_number} not found."
         
         vote = data['houseRollCallVote']
-        return format_house_vote_detail(vote)
+        vote_dict = vote[0] if isinstance(vote, list) and vote else vote
+        return structured(format_house_vote_detail(vote), "house_vote", [vote_dict])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -611,7 +613,8 @@ async def get_house_vote_details_enhanced(ctx: Context, congress: int, session: 
 - **Last Updated**: {vote_details.get('updateDate', 'N/A')}
 """
         
-        return f"# Enhanced House Vote Details\n\n{basic_result}{enhanced_section}"
+        text = f"# Enhanced House Vote Details\n\n{basic_result}{enhanced_section}"
+        return structured(text, "house_vote", [vote_details])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)

--- a/congress_api/features/members.py
+++ b/congress_api/features/members.py
@@ -7,6 +7,7 @@ from ..core.api_wrapper import DefensiveAPIWrapper, safe_congressional_request
 from ..core.congress_dates import current_congress
 from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import ResponseProcessor
+from ..utils.structured import structured
 import logging
 
 logger = logging.getLogger(__name__)
@@ -163,7 +164,7 @@ async def get_member_details(ctx: Context, bioguide_id: str) -> str:
         if "deathDate" in member:
             result.append(f"Death Date: {member['deathDate']}")
         
-        return "\n".join(result)
+        return structured("\n".join(result), "member", [member])
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -246,7 +247,7 @@ async def get_member_sponsored_legislation(ctx: Context, bioguide_id: str, limit
             if "url" in bill:
                 result.append(f"[View Details]({bill['url']})")
         
-        return "\n".join(result)
+        return structured("\n".join(result), "bill", legislation)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -326,7 +327,7 @@ async def get_member_cosponsored_legislation(ctx: Context, bioguide_id: str, lim
             if "url" in bill:
                 result.append(f"[View Details]({bill['url']})")
         
-        return "\n".join(result)
+        return structured("\n".join(result), "bill", legislation)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -392,7 +393,7 @@ async def get_members_by_congress(ctx: Context, congress: int, current_member: O
         for member in members:
             result.append("\n" + format_member_summary(member))
 
-        return "\n".join(result)
+        return structured("\n".join(result), "member", members)
 
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -455,7 +456,7 @@ async def get_members_by_state(ctx: Context, state_code: str, current_member: Op
         for member in members:
             result.append("\n" + format_member_summary(member))
         
-        return "\n".join(result)
+        return structured("\n".join(result), "member", members)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -517,7 +518,7 @@ async def get_members_by_district(ctx: Context, state_code: str, district: int, 
         for member in members:
             result.append("\n" + format_member_summary(member))
         
-        return "\n".join(result)
+        return structured("\n".join(result), "member", members)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -795,7 +796,7 @@ async def search_members(
         for member in filtered_members:
             result.append("\n" + format_member_summary(member))
         
-        return "\n".join(result)
+        return structured("\n".join(result), "member", filtered_members)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -911,7 +912,7 @@ async def get_members_by_congress_state_district(
         for member in filtered_members:
             result.append("\n" + format_member_summary(member))
         
-        return "\n".join(result)
+        return structured("\n".join(result), "member", filtered_members)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)

--- a/congress_api/features/nominations.py
+++ b/congress_api/features/nominations.py
@@ -12,6 +12,7 @@ from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator
 from ..core.exceptions import CommonErrors, format_error_response
 from ..core.response_utils import ResponseProcessor
+from ..utils.structured import structured
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -241,7 +242,7 @@ async def get_latest_nominations(ctx: Context) -> str:
     for idx, nomination in enumerate(nominations, 1):
         lines.append(f"## {idx}. {format_nomination_item(nomination)}\n")
     
-    return "\n".join(lines)
+    return structured("\n".join(lines), "nomination", nominations)
 
 # @require_paid_access
 async def get_nominations_by_congress(ctx: Context, congress: int) -> str:
@@ -286,7 +287,7 @@ async def get_nominations_by_congress(ctx: Context, congress: int) -> str:
     for idx, nomination in enumerate(nominations, 1):
         lines.append(f"## {idx}. {format_nomination_item(nomination)}\n")
     
-    return "\n".join(lines)
+    return structured("\n".join(lines), "nomination", nominations)
 
 # @require_paid_access
 async def get_nomination_details(ctx: Context, congress: int, nomination_number: int) -> str:
@@ -326,7 +327,7 @@ async def get_nomination_details(ctx: Context, congress: int, nomination_number:
     logger.info(f"Found nomination details for {nomination_number}, Congress {congress}")
     
     # Format and return the result
-    return format_nomination_detail(nomination)
+    return structured(format_nomination_detail(nomination), "nomination", [nomination])
 
 # @require_paid_access
 async def get_nomination_nominees(ctx: Context, congress: int, nomination_number: int, ordinal: int) -> str:
@@ -636,4 +637,4 @@ async def search_nominations(
         lines.append(f"## {i}. {format_nomination_item(nomination)}")
         lines.append("")
     
-    return "\n".join(lines)
+    return structured("\n".join(lines), "nomination", deduplicated_nominations)

--- a/congress_api/features/senate_communications.py
+++ b/congress_api/features/senate_communications.py
@@ -6,6 +6,7 @@ from ..core.api_wrapper import safe_congressional_request
 from ..core.validators import ParameterValidator
 from ..core.exceptions import CommonErrors, format_error_response, CongressionalAPIError
 from ..core.response_utils import SenateCommunicationsProcessor, clean_senate_communications_response
+from ..utils.structured import structured
 
 # Set up logger
 logger = logging.getLogger(__name__)
@@ -182,7 +183,8 @@ async def get_senate_communication_details(
         # Check for different possible response formats
         if 'senateCommunication' in data:
             logger.info(f"Retrieved senate communication using 'senateCommunication' key")
-            return format_senate_communication_detail(data)
+            comm_record = data['senateCommunication']
+            return structured(format_senate_communication_detail(data), "communication", [comm_record])
         else:
             # If the expected key is not found, log the keys and return a formatted version of whatever we got
             logger.warning(f"Unexpected response format. Keys: {list(data.keys()) if isinstance(data, dict) else 'Not a dictionary'}")
@@ -272,7 +274,8 @@ async def search_senate_communications(
         elif communication_type:
             title = f"Senate Communications - Type: {communication_type.upper()}"
         
-        return format_senate_communications_list(processed_communications, title)
+        formatted = format_senate_communications_list(processed_communications, title)
+        return structured(formatted, "communication", processed_communications)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)

--- a/congress_api/models/responses.py
+++ b/congress_api/models/responses.py
@@ -1,18 +1,24 @@
 """
 Pydantic models for Congressional MCP tool responses.
 Provides structured, typed responses optimized for AI agent consumption.
+
+Item models mirror what the Congress.gov list endpoints actually return
+(issue #55): list responses often omit fields that only exist on detail
+endpoints (nominee names, hearing titles, vote tallies, ...), so every
+field that the live API can omit is Optional with a None default. The
+response models' `results_count` MUST equal the number of items in the
+populated list(s); converters derive it with len(), never by parsing text.
 """
 
 from typing import List, Optional, Dict, Any, Union
 from pydantic import BaseModel, Field
-from datetime import datetime
 
 # Base Response Models
 class BaseResponse(BaseModel):
     """Base response model with common fields."""
     success: bool = Field(description="Whether the operation was successful")
     operation: str = Field(description="The operation that was performed")
-    
+
 class ErrorResponse(BaseResponse):
     """Error response model."""
     error: str = Field(description="Error message describing what went wrong")
@@ -26,145 +32,181 @@ class BillSummary(BaseModel):
     bill_type: str = Field(description="Type of bill (HR, S, HJRES, SJRES, etc.)")
     bill_number: int = Field(description="Bill number within the congress")
     title: str = Field(description="Official title of the bill")
-    sponsor: Optional[str] = Field(description="Primary sponsor of the bill")
-    introduced_date: Optional[str] = Field(description="Date bill was introduced (YYYY-MM-DD)")
-    latest_action: Optional[str] = Field(description="Most recent action taken on the bill")
-    url: Optional[str] = Field(description="Congress.gov URL for full bill details")
+    sponsor: Optional[str] = Field(default=None, description="Primary sponsor of the bill")
+    introduced_date: Optional[str] = Field(default=None, description="Date bill was introduced (YYYY-MM-DD)")
+    latest_action: Optional[str] = Field(default=None, description="Most recent action taken on the bill")
+    url: Optional[str] = Field(default=None, description="Congress.gov URL for full bill details")
 
 class AmendmentSummary(BaseModel):
     """Summary information about an amendment."""
     congress: int = Field(description="Congress number")
     amendment_type: str = Field(description="Type of amendment (HAMDT, SAMDT, etc.)")
     amendment_number: int = Field(description="Amendment number")
-    purpose: Optional[str] = Field(description="Purpose/description of the amendment")
-    sponsor: Optional[str] = Field(description="Amendment sponsor")
-    submitted_date: Optional[str] = Field(description="Date amendment was submitted")
-    bill_number: Optional[str] = Field(description="Bill this amendment applies to")
-    url: Optional[str] = Field(description="Congress.gov URL for amendment details")
+    purpose: Optional[str] = Field(default=None, description="Purpose/description of the amendment")
+    sponsor: Optional[str] = Field(default=None, description="Amendment sponsor")
+    submitted_date: Optional[str] = Field(default=None, description="Date amendment was submitted")
+    bill_number: Optional[str] = Field(default=None, description="Bill this amendment applies to")
+    url: Optional[str] = Field(default=None, description="Congress.gov URL for amendment details")
 
 class MemberSummary(BaseModel):
-    """Summary information about a member of Congress."""
+    """Summary information about a member of Congress (list-level fields)."""
     bioguide_id: str = Field(description="Unique bioguide identifier for the member")
     name: str = Field(description="Full name of the member")
-    party: Optional[str] = Field(description="Political party (D, R, I)")
-    state: Optional[str] = Field(description="State the member represents")
-    district: Optional[str] = Field(description="District number (for House members)")
-    chamber: str = Field(description="Chamber (House or Senate)")
-    current_member: bool = Field(description="Whether this person is currently serving")
-    url: Optional[str] = Field(description="Congress.gov URL for member details")
+    party: Optional[str] = Field(default=None, description="Political party")
+    state: Optional[str] = Field(default=None, description="State the member represents")
+    district: Optional[str] = Field(default=None, description="District number (House members)")
+    chamber: Optional[str] = Field(default=None, description="Chamber of the member's most recent term")
+    current_member: Optional[bool] = Field(default=None, description="Whether currently serving (None if unknown)")
+    url: Optional[str] = Field(default=None, description="Congress.gov API URL for member details")
 
 class CommitteeSummary(BaseModel):
     """Summary information about a committee."""
-    committee_code: str = Field(description="Official committee code")
+    committee_code: str = Field(description="Official committee system code (e.g. hsju00)")
     name: str = Field(description="Full committee name")
-    chamber: str = Field(description="Chamber (House, Senate, Joint)")
-    committee_type: str = Field(description="Type of committee (Standing, Select, etc.)")
-    url: Optional[str] = Field(description="Congress.gov URL for committee details")
+    chamber: Optional[str] = Field(default=None, description="Chamber (House, Senate, Joint)")
+    committee_type: Optional[str] = Field(default=None, description="Type of committee (Standing, Select, ...)")
+    url: Optional[str] = Field(default=None, description="Congress.gov API URL for committee details")
 
-# Legislation Hub Response
+# Legislation Hub Response (legacy)
 class LegislationHubResponse(BaseResponse):
     """Response from the legislation hub tool."""
     results_count: int = Field(description="Number of results returned")
-    total_available: Optional[int] = Field(description="Total results available (if known)")
+    total_available: Optional[int] = Field(default=None, description="Total results available (if known)")
     bills: List[BillSummary] = Field(default=[], description="Bill results")
     amendments: List[AmendmentSummary] = Field(default=[], description="Amendment results")
     summary: str = Field(description="Human-readable summary of the results")
     next_steps: List[str] = Field(default=[], description="Suggested next actions or related searches")
 
-# Members & Committees Response  
+# Members & Committees Response
 class MembersCommitteesResponse(BaseResponse):
-    """Response from the members and committees tool."""
-    results_count: int = Field(description="Number of results returned")
+    """Response from the members and committees tools.
+
+    Some operations return items that are neither members nor committees
+    (a member's sponsored bills, a committee's reports/communications/
+    nominations); those arrive in `items` as the API's own dicts, labeled
+    by `item_kind`.
+    """
+    results_count: int = Field(description="Number of items returned (equals the populated list's length)")
     members: List[MemberSummary] = Field(default=[], description="Member results")
     committees: List[CommitteeSummary] = Field(default=[], description="Committee results")
+    items: List[Dict[str, Any]] = Field(
+        default=[],
+        description="Results of other kinds (bills, reports, communications, nominations), as returned by Congress.gov")
+    item_kind: Optional[str] = Field(
+        default=None,
+        description="What `items` contains (bill, committee_report, communication, nomination, ...)")
     summary: str = Field(description="Human-readable summary of the results")
     context: str = Field(description="Context about the search or operation performed")
 
 # Voting & Nominations Response
 class VoteSummary(BaseModel):
-    """Summary of a vote."""
-    vote_number: int = Field(description="Vote number")
-    chamber: str = Field(description="Chamber where vote occurred (House/Senate)")
-    date: str = Field(description="Date of the vote")
-    description: str = Field(description="Description of what was voted on")
-    result: str = Field(description="Vote result (Passed, Failed, etc.)")
-    vote_counts: Dict[str, int] = Field(description="Vote breakdown (Yea, Nay, Present, Not Voting)")
-    url: Optional[str] = Field(description="Congress.gov URL for vote details")
+    """Summary of a House roll-call vote (list-level fields)."""
+    vote_number: int = Field(description="Roll call vote number")
+    congress: Optional[int] = Field(default=None, description="Congress number")
+    session: Optional[int] = Field(default=None, description="Session number")
+    chamber: Optional[str] = Field(default=None, description="Chamber where the vote occurred")
+    legislation: Optional[str] = Field(default=None, description="Legislation voted on (e.g. 'HR 5348')")
+    vote_type: Optional[str] = Field(default=None, description="Vote type (Yea-And-Nay, 2/3 Yea-And-Nay, ...)")
+    result: Optional[str] = Field(default=None, description="Vote result (Passed, Failed, ...)")
+    date: Optional[str] = Field(default=None, description="Start date/time of the vote")
+    vote_counts: Optional[Dict[str, int]] = Field(default=None, description="Tallies (detail operations only)")
+    url: Optional[str] = Field(default=None, description="Congress.gov API URL for vote details")
 
 class NominationSummary(BaseModel):
-    """Summary of a nomination."""
+    """Summary of a nomination (list-level fields)."""
     nomination_number: str = Field(description="Nomination number")
-    nominee: str = Field(description="Name of the nominee")
-    position: str = Field(description="Position being nominated for")
-    organization: str = Field(description="Organization/agency")
-    received_date: Optional[str] = Field(description="Date nomination was received")
-    status: Optional[str] = Field(description="Current status of nomination")
-    url: Optional[str] = Field(description="Congress.gov URL for nomination details")
+    citation: Optional[str] = Field(default=None, description="Citation (e.g. PN123)")
+    congress: Optional[int] = Field(default=None, description="Congress number")
+    organization: Optional[str] = Field(default=None, description="Organization/agency")
+    is_military: Optional[bool] = Field(default=None, description="Whether a military nomination")
+    nominee: Optional[str] = Field(default=None, description="Nominee name (detail operations only)")
+    position: Optional[str] = Field(default=None, description="Position (detail operations only)")
+    received_date: Optional[str] = Field(default=None, description="Date the nomination was received")
+    latest_action: Optional[str] = Field(default=None, description="Most recent action text")
+    update_date: Optional[str] = Field(default=None, description="Last update timestamp")
+    url: Optional[str] = Field(default=None, description="Congress.gov API URL for nomination details")
 
 class VotingNominationsResponse(BaseResponse):
     """Response from the voting and nominations tool."""
-    results_count: int = Field(description="Number of results returned")
+    results_count: int = Field(description="Number of items returned (equals the populated list's length)")
     votes: List[VoteSummary] = Field(default=[], description="Vote results")
     nominations: List[NominationSummary] = Field(default=[], description="Nomination results")
     summary: str = Field(description="Human-readable summary of the results")
 
 # Records & Hearings Response
 class HearingSummary(BaseModel):
-    """Summary of a committee hearing."""
-    congress: int = Field(description="Congress number")
-    chamber: str = Field(description="Chamber (House/Senate)")
+    """Summary of a committee hearing (list-level fields)."""
     jacket_number: str = Field(description="Hearing jacket number")
-    title: str = Field(description="Hearing title")
-    committee: str = Field(description="Committee that held the hearing")
-    date: Optional[str] = Field(description="Hearing date")
-    url: Optional[str] = Field(description="Congress.gov URL for hearing details")
+    congress: Optional[int] = Field(default=None, description="Congress number")
+    chamber: Optional[str] = Field(default=None, description="Chamber (House/Senate/NoChamber)")
+    title: Optional[str] = Field(default=None, description="Hearing title (detail operations only)")
+    committee: Optional[str] = Field(default=None, description="Committee (detail operations only)")
+    date: Optional[str] = Field(default=None, description="Hearing date")
+    update_date: Optional[str] = Field(default=None, description="Last update timestamp")
+    url: Optional[str] = Field(default=None, description="Congress.gov API URL for hearing details")
 
 class RecordSummary(BaseModel):
-    """Summary of a Congressional Record entry."""
-    volume: int = Field(description="Congressional Record volume")
-    issue: int = Field(description="Issue number")
-    date: str = Field(description="Publication date")
-    section: str = Field(description="Section of the record (House, Senate, Extensions)")
-    title: str = Field(description="Title or topic")
-    url: Optional[str] = Field(description="Congress.gov URL for full text")
+    """Summary of a Congressional Record issue (list-level fields)."""
+    volume: Optional[int] = Field(default=None, description="Congressional Record volume")
+    issue: Optional[int] = Field(default=None, description="Issue number")
+    session: Optional[int] = Field(default=None, description="Session number")
+    congress: Optional[int] = Field(default=None, description="Congress number")
+    date: Optional[str] = Field(default=None, description="Publication date")
+    id: Optional[str] = Field(default=None, description="Record id")
+    title: Optional[str] = Field(default=None, description="Title, where available")
+    url: Optional[str] = Field(default=None, description="URL for the issue, where available")
 
 class RecordsHearingsResponse(BaseResponse):
-    """Response from the records and hearings tool."""
-    results_count: int = Field(description="Number of results returned")
+    """Response from the records and hearings tool.
+
+    Communications and House requirements arrive in `items` as the API's
+    own dicts, labeled by `item_kind`.
+    """
+    results_count: int = Field(description="Number of items returned (equals the populated list's length)")
     hearings: List[HearingSummary] = Field(default=[], description="Hearing results")
     records: List[RecordSummary] = Field(default=[], description="Congressional Record results")
+    items: List[Dict[str, Any]] = Field(
+        default=[],
+        description="Results of other kinds (communications, requirements), as returned by Congress.gov")
+    item_kind: Optional[str] = Field(
+        default=None,
+        description="What `items` contains (communication, requirement, daily_record, bound_record, ...)")
     summary: str = Field(description="Human-readable summary of the results")
 
 # Committee Intelligence Response
 class CommitteeActivitySummary(BaseModel):
-    """Summary of committee activity."""
-    committee_name: str = Field(description="Committee name")
-    activity_type: str = Field(description="Type of activity (meeting, markup, hearing)")
-    title: str = Field(description="Activity title")
-    date: Optional[str] = Field(description="Activity date")
-    status: str = Field(description="Current status")
-    url: Optional[str] = Field(description="Congress.gov URL for details")
+    """Summary of a committee report, print, or meeting (list-level fields)."""
+    activity_type: str = Field(description="Type of activity (report, print, meeting)")
+    citation: Optional[str] = Field(default=None, description="Citation (e.g. 'H. Rept. 119-10')")
+    identifier: Optional[str] = Field(default=None, description="Report number, jacket number, or event id")
+    congress: Optional[int] = Field(default=None, description="Congress number")
+    chamber: Optional[str] = Field(default=None, description="Chamber")
+    committee_name: Optional[str] = Field(default=None, description="Committee name, where available")
+    title: Optional[str] = Field(default=None, description="Title, where available")
+    date: Optional[str] = Field(default=None, description="Activity or update date")
+    url: Optional[str] = Field(default=None, description="Congress.gov API URL for details")
 
 class CommitteeIntelligenceResponse(BaseResponse):
     """Response from the committee intelligence tool."""
-    results_count: int = Field(description="Number of results returned")
+    results_count: int = Field(description="Number of items returned (equals the populated list's length)")
     activities: List[CommitteeActivitySummary] = Field(default=[], description="Committee activity results")
     summary: str = Field(description="Human-readable summary of committee intelligence")
     insights: List[str] = Field(default=[], description="Key insights about committee activity")
 
-# Research & Professional Response  
+# Research & Professional Response
 class ResearchSummary(BaseModel):
-    """Summary of research material."""
-    title: str = Field(description="Research document title")
-    type: str = Field(description="Type of document (CRS Report, Committee Report, etc.)")
-    date: Optional[str] = Field(description="Publication or update date")
-    summary: Optional[str] = Field(description="Brief summary of the document")
+    """Summary of research material (list-level fields)."""
+    title: str = Field(description="Document or congress title")
+    type: str = Field(description="Type of material (CRS Report, Congress, ...)")
+    date: Optional[str] = Field(default=None, description="Publication or update date")
+    status: Optional[str] = Field(default=None, description="Status, where available")
+    summary: Optional[str] = Field(default=None, description="Brief summary of the document")
     topics: List[str] = Field(default=[], description="Key topics covered")
-    url: Optional[str] = Field(description="URL to access the document")
+    url: Optional[str] = Field(default=None, description="URL to access the document")
 
 class ResearchProfessionalResponse(BaseResponse):
     """Response from the research and professional tool."""
-    results_count: int = Field(description="Number of results returned")
+    results_count: int = Field(description="Number of items returned (equals the populated list's length)")
     research_materials: List[ResearchSummary] = Field(default=[], description="Research materials found")
     summary: str = Field(description="Human-readable summary of research results")
     recommended_reading: List[str] = Field(default=[], description="Recommended follow-up reading")
@@ -172,7 +214,7 @@ class ResearchProfessionalResponse(BaseResponse):
 # Union type for all possible tool responses
 ToolResponse = Union[
     LegislationHubResponse,
-    MembersCommitteesResponse, 
+    MembersCommitteesResponse,
     VotingNominationsResponse,
     RecordsHearingsResponse,
     CommitteeIntelligenceResponse,

--- a/congress_api/utils/response_converters.py
+++ b/congress_api/utils/response_converters.py
@@ -1,12 +1,18 @@
 """
-Response converters - Extract structured Pydantic models from raw API responses.
+Response converters - build structured Pydantic responses from impl output.
 
-Centralizes the conversion logic previously duplicated across deprecated bucket files.
+Impls return pre-formatted markdown. When they attach the real item dicts
+via congress_api.utils.structured.structured(), the converter here maps
+them into the typed lists and derives results_count with len(). Plain
+strings fall back to the legacy count-phrase regex with empty lists
+(accurate for error/empty messages; a lie-free zero otherwise only when
+the impl genuinely returned nothing).
 """
 
 import json
 import logging
 import re
+from typing import Any, Dict, List, Optional, Tuple
 
 from ..models.responses import (
     CommitteeSummary,
@@ -16,11 +22,9 @@ from ..models.responses import (
 
 logger = logging.getLogger(__name__)
 
-# Impls across the codebase report their count in prose rather than a
-# structured field, since these converters receive pre-formatted markdown
-# rather than raw JSON (see _extract_json). Two phrasings are common:
-# "Found 191 bills:" (members.py, committees.py, ...) and
-# "(10 found)" (committee_reports.py, hearings.py, ...).
+# Legacy fallback only (plain-str responses): impls report their count in
+# prose. "Found 191 bills:" (members.py, committees.py, ...) and
+# "(10 found)" (committee_reports.py, ...).
 _COUNT_PATTERNS = (
     re.compile(r"Found\s+(\d+)", re.IGNORECASE),
     re.compile(r"\((\d+)\s+found\)", re.IGNORECASE),
@@ -28,11 +32,7 @@ _COUNT_PATTERNS = (
 
 
 def _extract_result_count(text: str) -> int:
-    """Best-effort recovery of a result count from a summary's count phrase.
-
-    Returns 0 if no recognized count phrase is found — a limitation, not a
-    regression: results_count was unconditionally 0 before this helper existed.
-    """
+    """Best-effort count recovery from a plain string's count phrase."""
     for pattern in _COUNT_PATTERNS:
         match = pattern.search(text)
         if match:
@@ -79,74 +79,132 @@ def _extract_json(raw_response: str) -> dict | None:
     return None
 
 
-def convert_members_committees_response(raw_response: str, operation: str) -> MembersCommitteesResponse:
-    """Convert raw string response to structured MembersCommitteesResponse."""
+def structured_items_of(raw_response: str) -> Tuple[Optional[str], Optional[List[Dict[str, Any]]]]:
+    """Return (item_kind, items) if the impl attached real data, else (None, None)."""
+    items = getattr(raw_response, "structured_items", None)
+    kind = getattr(raw_response, "item_kind", None)
+    if isinstance(items, list):
+        return kind, items
+    return None, None
+
+
+def _int_or_none(value: Any) -> Optional[int]:
     try:
-        if isinstance(raw_response, str):
-            data = _extract_json(raw_response)
-            if data is None:
-                # All members/committees impls return pre-formatted human-readable
-                # markdown, not JSON, so this "no JSON found" branch is the NORMAL
-                # path for every one of these tools, not a fallback for malformed
-                # data. It must therefore preserve the full response: a prior bug
-                # here truncated it to raw_response[:500], which for any member or
-                # committee with more than a handful of results cut the summary off
-                # mid-word (and always reported results_count=0 regardless of how
-                # much data was actually returned).
-                return MembersCommitteesResponse(
-                    success=True,
-                    operation=operation,
-                    results_count=_extract_result_count(raw_response),
-                    members=[],
-                    committees=[],
-                    summary=raw_response,
-                    context=f"Performed {operation} operation",
-                )
-        else:
-            data = raw_response
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
-        members = []
-        committees = []
 
-        if isinstance(data, dict):
-            if "members" in data:
-                for member_data in data.get("members", []):
-                    if isinstance(member_data, dict):
-                        members.append(
-                            MemberSummary(
-                                bioguide_id=member_data.get("bioguideId", ""),
-                                name=member_data.get("name", ""),
-                                party=member_data.get("partyName"),
-                                state=member_data.get("state"),
-                                district=member_data.get("district"),
-                                chamber=member_data.get("chamber", ""),
-                                current_member=member_data.get("currentMember", False),
-                                url=member_data.get("url"),
-                            )
-                        )
+def _latest_term(member: Dict[str, Any]) -> Dict[str, Any]:
+    """Most recent term dict from a member record (greatest startYear)."""
+    terms = member.get("terms")
+    if isinstance(terms, dict):
+        terms = terms.get("item")
+    if not isinstance(terms, list):
+        return {}
+    dict_terms = [t for t in terms if isinstance(t, dict)]
+    if not dict_terms:
+        return {}
 
-            if "committees" in data:
-                for committee_data in data.get("committees", []):
-                    if isinstance(committee_data, dict):
-                        committees.append(
-                            CommitteeSummary(
-                                committee_code=committee_data.get("systemCode", ""),
-                                name=committee_data.get("name", ""),
-                                chamber=committee_data.get("chamber", ""),
-                                committee_type=committee_data.get("committeeTypeCode", ""),
-                                url=committee_data.get("url"),
-                            )
-                        )
+    def _key(t):
+        start = _int_or_none(t.get("startYear"))
+        open_ended = 1 if t.get("endYear") in (None, "", "Present") else 0
+        return (start if start is not None else -1, open_ended)
 
-        results_count = len(members) + len(committees)
+    return max(dict_terms, key=_key)
 
+
+def _member_name(member: Dict[str, Any]) -> str:
+    name = member.get("name")
+    if isinstance(name, str) and name:
+        return name
+    if isinstance(name, dict):
+        first, last = name.get("firstName", ""), name.get("lastName", "")
+        if first or last:
+            return f"{last}, {first}".strip(", ")
+    return member.get("invertedOrderName") or member.get("directOrderName") \
+        or member.get("bioguideId", "")
+
+
+def map_member(member: Dict[str, Any]) -> MemberSummary:
+    """Map a Congress.gov member list dict to MemberSummary."""
+    party = member.get("partyName") or member.get("party")
+    if not party:
+        history = member.get("partyHistory")
+        if isinstance(history, list) and history and isinstance(history[0], dict):
+            party = history[0].get("partyName") or history[0].get("partyAbbreviation")
+    term = _latest_term(member)
+    current = None
+    if term:
+        current = term.get("endYear") in (None, "", "Present")
+    district = member.get("district")
+    return MemberSummary(
+        bioguide_id=member.get("bioguideId", ""),
+        name=_member_name(member),
+        party=party,
+        state=member.get("state"),
+        district=str(district) if district is not None else None,
+        chamber=term.get("chamber") or member.get("chamber"),
+        current_member=current,
+        url=member.get("url"),
+    )
+
+
+def map_committee(committee: Dict[str, Any]) -> CommitteeSummary:
+    """Map a Congress.gov committee list dict to CommitteeSummary."""
+    return CommitteeSummary(
+        committee_code=committee.get("systemCode", ""),
+        name=committee.get("name", ""),
+        chamber=committee.get("chamber"),
+        committee_type=committee.get("committeeTypeCode") or committee.get("type"),
+        url=committee.get("url"),
+    )
+
+
+def convert_members_committees_response(raw_response: str, operation: str) -> MembersCommitteesResponse:
+    """Convert impl output to a structured MembersCommitteesResponse.
+
+    The summary is ALWAYS the impl's full markdown (a prior bug truncated
+    it to 500 chars). When the impl attached real items, the typed lists
+    are populated from them and results_count == len(items); member/
+    committee dicts map to their models, anything else (bills, reports,
+    communications, nominations) passes through in `items` labeled by
+    `item_kind`.
+    """
+    try:
+        kind, items = structured_items_of(raw_response)
+        if items is not None:
+            members: List[MemberSummary] = []
+            committees: List[CommitteeSummary] = []
+            generic: List[Dict[str, Any]] = []
+            if kind == "member":
+                members = [map_member(i) for i in items]
+            elif kind == "committee":
+                committees = [map_committee(i) for i in items]
+            else:
+                generic = items
+            return MembersCommitteesResponse(
+                success=True,
+                operation=operation,
+                results_count=len(items),
+                members=members,
+                committees=committees,
+                items=generic,
+                item_kind=kind,
+                summary=str(raw_response),
+                context=f"Performed {operation} operation",
+            )
+
+        # Legacy path: plain markdown with no attached data (error and
+        # empty-result messages, and impls not yet converted). Preserve the
+        # full text; recover a count from the count phrase if present.
         return MembersCommitteesResponse(
             success=True,
             operation=operation,
-            results_count=results_count,
-            members=members,
-            committees=committees,
-            summary=f"Found {len(members)} members and {len(committees)} committees",
+            results_count=_extract_result_count(raw_response),
+            members=[],
+            committees=[],
+            summary=str(raw_response),
             context=f"Performed {operation} operation",
         )
 

--- a/congress_api/utils/structured.py
+++ b/congress_api/utils/structured.py
@@ -1,0 +1,46 @@
+"""Carrier for structured items alongside formatted markdown.
+
+Impl functions across congress_api/features return pre-formatted markdown
+strings. The response converters that build the typed Pydantic responses
+only ever saw that markdown, so they guessed `results_count` with regexes
+and always emitted empty typed lists (issue #55).
+
+StructuredText lets an impl hand the converter the real, cleaned item dicts
+it already holds at format time — without changing any function signature:
+it IS a str (every existing consumer, test, and `-> str` annotation keeps
+working), it just also carries `.structured_items` and `.item_kind`.
+
+Usage in an impl, immediately before the existing return:
+
+    return structured("\n".join(result), "member", filtered_members)
+
+Converters read the attributes with getattr(...) and fall back to the
+legacy regex path for plain strings.
+"""
+from typing import Any, Dict, List, Optional
+
+
+class StructuredText(str):
+    """A str subclass that also carries the structured items behind it."""
+
+    item_kind: Optional[str]
+    structured_items: List[Dict[str, Any]]
+
+    def __new__(cls, text: str, item_kind: Optional[str] = None,
+                items: Optional[List[Dict[str, Any]]] = None):
+        obj = super().__new__(cls, text)
+        obj.item_kind = item_kind
+        obj.structured_items = [i for i in (items or []) if isinstance(i, dict)]
+        return obj
+
+
+def structured(text: str, item_kind: str,
+               items: Optional[List[Dict[str, Any]]] = None) -> StructuredText:
+    """Attach real item dicts (and their kind) to a formatted response.
+
+    `items` is the cleaned/deduplicated/limited list the markdown was
+    rendered from — pass exactly what was formatted, so the typed list and
+    the summary can never disagree. For single-record detail responses pass
+    a one-element list.
+    """
+    return StructuredText(text, item_kind, items)

--- a/tests/test_structured_population.py
+++ b/tests/test_structured_population.py
@@ -169,5 +169,8 @@ def test_converters_never_raise_on_junk_items():
     resp = _convert_to_structured_response(
         StructuredText("text", "house_vote", [{"rollCallNumber": "not-an-int"}]),
         "get_house_votes_by_congress")
-    # junk falls into the except branch -> success=False, never an exception
-    assert resp.success is False or resp.results_count in (0, 1)
+    # junk falls into the except branch -> success=False with the error noted,
+    # never an exception propagating out of the converter
+    assert resp.success is False
+    assert resp.results_count == 0
+    assert "Error processing response" in resp.summary

--- a/tests/test_structured_population.py
+++ b/tests/test_structured_population.py
@@ -1,0 +1,173 @@
+"""Issue #55: typed lists and results_count must reflect real data.
+
+Converter-level tests using StructuredText carriers; end-to-end wrapper
+coverage lives alongside (mocked API -> populated lists).
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from congress_api.utils.structured import StructuredText, structured  # noqa: E402
+from congress_api.utils.response_converters import (  # noqa: E402
+    convert_members_committees_response,
+)
+
+
+def test_structured_text_is_str():
+    s = structured("# Found 2 members:", "member", [{"bioguideId": "X"}])
+    assert isinstance(s, str)
+    assert s == "# Found 2 members:"
+    assert s.item_kind == "member"
+    assert len(s.structured_items) == 1
+    # non-dict entries are dropped defensively
+    assert structured("t", "member", [{"a": 1}, "junk", None]).structured_items == [{"a": 1}]
+
+
+def _schumer():
+    return {
+        "bioguideId": "S000148",
+        "name": "Schumer, Charles E.",
+        "partyName": "Democratic",
+        "state": "New York",
+        "url": "https://api.congress.gov/v3/member/S000148?format=json",
+        "terms": {"item": [
+            {"chamber": "House of Representatives", "startYear": 1981, "endYear": 1999},
+            {"chamber": "Senate", "startYear": 1999, "endYear": None},
+        ]},
+    }
+
+
+def test_members_converter_populates_from_items():
+    raw = structured("# Member Search Results\nFound 1 members:\n...", "member", [_schumer()])
+    resp = convert_members_committees_response(raw, "search_members")
+    assert resp.results_count == 1
+    assert len(resp.members) == 1
+    m = resp.members[0]
+    assert m.bioguide_id == "S000148"
+    assert m.chamber == "Senate"            # latest term, not oldest
+    assert m.current_member is True
+    assert m.party == "Democratic"
+    assert resp.summary.startswith("# Member Search Results")
+    assert resp.items == [] and resp.item_kind == "member"
+
+
+def test_committees_converter_populates_from_items():
+    raw = structured("Committees matching 'judiciary':\n...", "committee", [{
+        "systemCode": "ssju00", "name": "Judiciary Committee",
+        "chamber": "Senate", "committeeTypeCode": "Standing",
+        "url": "https://api.congress.gov/v3/committee/senate/ssju00?format=json",
+    }])
+    resp = convert_members_committees_response(raw, "search_committees")
+    assert resp.results_count == 1
+    assert resp.committees[0].committee_code == "ssju00"
+    assert resp.committees[0].chamber == "Senate"
+
+
+def test_other_kinds_pass_through_in_items():
+    bills = [{"type": "HR", "number": "1", "congress": 119, "url": "u"}] * 3
+    raw = structured("# Sponsored Legislation\nFound 3 bills:", "bill", bills)
+    resp = convert_members_committees_response(raw, "get_member_sponsored_legislation")
+    assert resp.results_count == 3
+    assert resp.members == [] and resp.committees == []
+    assert resp.item_kind == "bill"
+    assert len(resp.items) == 3 and resp.items[0]["type"] == "HR"
+
+
+def test_plain_string_falls_back_to_legacy_count():
+    resp = convert_members_committees_response("# X\nFound 20 bills:\n...", "op")
+    assert resp.results_count == 20
+    assert resp.members == [] and resp.items == []
+
+
+def test_error_string_stays_zero():
+    resp = convert_members_committees_response("No members found matching the criteria.", "op")
+    assert resp.results_count == 0 and resp.success is True
+
+
+def test_empty_items_means_zero_not_regex():
+    """An impl that attaches an empty list is authoritative: count 0 even if
+    the text contains a number the regex would catch."""
+    raw = structured("Found 999 in some unrelated prose", "member", [])
+    resp = convert_members_committees_response(raw, "op")
+    assert resp.results_count == 0
+
+
+def test_votes_converter():
+    from congress_api.features.buckets.voting_and_nominations import _convert_to_structured_response
+    votes = [{"congress": 119, "sessionNumber": 1, "rollCallNumber": 306,
+              "legislationType": "HR", "legislationNumber": "5348",
+              "voteType": "2/3 Yea-And-Nay", "result": "Passed",
+              "startDate": "2025-12-01T18:57:00-05:00",
+              "url": "https://api.congress.gov/v3/house-vote/119/1/306"}]
+    resp = _convert_to_structured_response(structured("# House Votes...", "house_vote", votes),
+                                           "get_house_votes_by_session")
+    assert resp.results_count == 1
+    v = resp.votes[0]
+    assert v.vote_number == 306 and v.legislation == "HR 5348" and v.result == "Passed"
+    assert resp.nominations == []
+
+
+def test_nominations_converter():
+    from congress_api.features.buckets.voting_and_nominations import _convert_to_structured_response
+    noms = [{"citation": "PN730-2", "congress": 119, "number": 730,
+             "organization": "Federal Labor Relations Authority",
+             "nominationType": {"isMilitary": False},
+             "receivedDate": "2026-01-13",
+             "latestAction": {"actionDate": "2026-08-07", "text": "Confirmed by the Senate"},
+             "updateDate": "2026-08-08", "url": "u"}]
+    resp = _convert_to_structured_response(structured("# Latest Nominations", "nomination", noms),
+                                           "get_latest_nominations")
+    assert resp.results_count == 1
+    n = resp.nominations[0]
+    assert n.nomination_number == "730" and n.citation == "PN730-2"
+    assert n.is_military is False and "Confirmed" in n.latest_action
+
+
+def test_committee_intelligence_converter():
+    from congress_api.features.buckets.committee_intelligence import _convert_to_structured_response
+    reports = [{"citation": "H. Rept. 119-10", "congress": 119, "chamber": "House",
+                "type": "HRPT", "number": 10, "updateDate": "2026-08-01", "url": "u"}]
+    resp = _convert_to_structured_response(structured("# Latest Committee Reports (1 found)",
+                                                      "committee_report", reports),
+                                           "get_latest_committee_reports")
+    assert resp.results_count == 1
+    a = resp.activities[0]
+    assert a.activity_type == "report" and a.citation == "H. Rept. 119-10" and a.identifier == "10"
+
+
+def test_records_hearings_converter():
+    from congress_api.features.buckets.records_and_hearings import _convert_to_structured_response
+    issues = [{"Congress": "119", "Issue": "134", "Volume": "172", "Session": "2",
+               "PublishDate": "2026-08-20", "Id": 27000}]
+    resp = _convert_to_structured_response(structured("Search Results - Congressional Record",
+                                                      "record", issues),
+                                           "search_congressional_record")
+    assert resp.results_count == 1
+    r = resp.records[0]
+    assert r.volume == 172 and r.issue == 134 and r.congress == 119 and r.id == "27000"
+
+    comms = [{"communicationNumber": 1, "communicationType": {"code": "ec"}}]
+    resp2 = _convert_to_structured_response(structured("comms", "communication", comms),
+                                            "search_house_communications")
+    assert resp2.results_count == 1 and resp2.item_kind == "communication"
+    assert resp2.items == comms and resp2.hearings == [] and resp2.records == []
+
+
+def test_research_converter():
+    from congress_api.features.buckets.research_and_professional import _convert_to_structured_response
+    reports = [{"title": "Iran Sanctions", "publishDate": "2026-01-01", "status": "Active", "url": "u"}]
+    resp = _convert_to_structured_response(structured("CRS", "crs_report", reports),
+                                           "search_crs_reports")
+    assert resp.results_count == 1
+    assert resp.research_materials[0].title == "Iran Sanctions"
+    assert resp.research_materials[0].type == "CRS Report"
+
+
+def test_converters_never_raise_on_junk_items():
+    from congress_api.features.buckets.voting_and_nominations import _convert_to_structured_response
+    resp = _convert_to_structured_response(
+        StructuredText("text", "house_vote", [{"rollCallNumber": "not-an-int"}]),
+        "get_house_votes_by_congress")
+    # junk falls into the except branch -> success=False, never an exception
+    assert resp.success is False or resp.results_count in (0, 1)


### PR DESCRIPTION
Fixes [#55](https://github.com/amurshak/congressMCP/issues/55): the typed half of every bucket/member/committee response was fabricated — converters regex-guessed `results_count` from markdown and always emitted empty lists, so a response could say `results_count: 0, votes: []` while its `summary` listed five votes.

## Design
- **`utils/structured.py`**: `structured(text, kind, items)` returns a `str` subclass carrying the real item dicts. Impls attach exactly the cleaned/deduplicated/limited list they formatted — no signature, annotation, or consumer changes.
- **Models realigned to reality**: item models now mirror what Congress.gov *list* endpoints return (fields that only exist on detail endpoints are Optional); `MembersCommitteesResponse`/`RecordsHearingsResponse` gain generic `items` + `item_kind` for result kinds without a typed model (bills, communications, requirements). `results_count` is documented as `len(items)`, never parsed from text.
- **Converters**: populate typed lists from attached items; the count-phrase regex survives only as the fallback for plain strings (errors, empty results).
- **Impl sweep**: ~45 success returns across 16 feature modules wrapped (members, committees, reports, prints, meetings, CRS, congress info, house votes, nominations, hearings, congressional/daily/bound record, communications, requirements). Detail ops attach one-element record lists.

## Verification
- 13 converter tests (`tests/test_structured_population.py`) incl. "attached empty list beats the regex".
- 261 related tests pass; the 4 `test_bucket_double_conversion` failures are the pre-existing Python-3.10 `Mock` issue (#45) and pass on CI's 3.12. `check_known_failures` + `audit_tool_schemas --check` clean; no touched file has more ruff errors than master.
- **Live over stdio, real API** — every case now coherent (`results_count == len(populated list)` with real fields):
  - `search_members(NY, senate, 119)` → 2 typed members (Schumer: `chamber: Senate`, `current_member: true`)
  - `get_house_votes_by_session(119,1)` → 4 typed votes (`vote_number: 306, legislation: "HR 5348", result: Passed`)
  - `get_latest_nominations` → 8 typed nominations (`citation: PN730-2`)
  - `get_latest_committee_reports` → 10 activities (`citation: "H. Rept. 119-10"`)
  - hearings, congressional record, communications, requirements, CRS, congress info, sponsored bills → all populated

Output schemas change (fields loosened/added, dead required fields relaxed): previously the typed fields were always empty, so nothing could have depended on the old shapes.

Closes #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)