### PR TITLE
Honest keyword search, real member votes, remove dead operations (#54, #56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ CONGRESS_API_KEY=your-key congressmcp --transport streamable-http --host 0.0.0.0
 
 | Toolset | Operations | What it does |
 |---------|-----------|--------------|
-| **Bills** | 16 | Search, details, text, actions, amendments, cosponsors, subjects |
+| **Bills** | 15 | Search, details, text, actions, amendments, cosponsors, subjects |
 | **Laws** | 2 | Enacted public/private laws by congress (`get_laws`, `get_law_details`) |
 | **Amendments** | 7 | Search, details, actions, sponsors, text |
 | **Treaties & Summaries** | 5 | Treaty search, actions, committees, text; bill summaries |

--- a/congress_api/features/amendments_tool.py
+++ b/congress_api/features/amendments_tool.py
@@ -82,7 +82,8 @@ async def amendments(
     
     SEARCH OPERATIONS:
     - get_amendments: Core amendments API access with filtering
-    - search_amendments: Search amendments by keywords and parameters
+    - search_amendments: filters the 250 most recently updated amendments
+      by purpose/description text (client-side; not full-text search)
     
     DETAILS OPERATIONS:
     - get_amendment_details: Complete amendment information and status

--- a/congress_api/features/bills_tool.py
+++ b/congress_api/features/bills_tool.py
@@ -44,10 +44,6 @@ async def route_bills_operation(ctx: Context, operation: str, **kwargs) -> str:
         from .buckets.bills import get_bill_titles
         validate_operation_kwargs(get_bill_titles, kwargs, operation)
         return await get_bill_titles(ctx, **kwargs)
-    elif operation == "get_bill_content":
-        from .buckets.bills import get_bill_content
-        validate_operation_kwargs(get_bill_content, kwargs, operation)
-        return await get_bill_content(ctx, **kwargs)
     elif operation == "get_bill_summaries":
         from .buckets.bills import get_bill_summaries
         validate_operation_kwargs(get_bill_summaries, kwargs, operation)
@@ -110,10 +106,6 @@ async def bills(
     fromDateTime: Optional[str] = None,
     toDateTime: Optional[str] = None,
     days_back: Optional[int] = None,
-    # Text and content
-    version: Optional[str] = None,
-    chunk_number: Optional[int] = None,
-    chunk_size: Optional[int] = None,
 ) -> str:
     """
     Comprehensive Bills Tool - All bill operations in one focused interface.
@@ -125,7 +117,9 @@ async def bills(
     CORE OPERATIONS:
     • Search & Discovery: search_bills, get_bills, get_recent_bills
     • Details & Metadata: get_bill_details, get_bill_titles, get_bill_subjects
-    • Text & Content: get_bill_text, get_bill_text_versions, get_bill_content
+    • Text & Content: get_bill_text, get_bill_text_versions
+      (for FULL bill text search/retrieval use the dedicated search_bill_text,
+      get_bill_section and get_bill_toc tools)
     • Summaries: get_bill_summaries
     • Relationships: get_bill_related_bills, get_bill_amendments
     • Legislative Process: get_bill_actions, get_bill_committees, get_bill_cosponsors
@@ -142,7 +136,6 @@ async def bills(
         limit: Results limit (max 250 for API compliance)
         sort: updateDate+desc (newest first) or updateDate+asc
         fromDateTime/toDateTime: Date range (YYYY-MM-DDTHH:MM:SSZ)
-        version: Text version for content operations
         
     Returns:
         Formatted results specific to requested operation
@@ -196,10 +189,7 @@ async def bills(
             'offset': offset,
             'fromDateTime': fromDateTime,
             'toDateTime': toDateTime,
-            'days_back': days_back,
-            'version': version,
-            'chunk_number': chunk_number,
-            'chunk_size': chunk_size
+            'days_back': days_back
         }.items():
             if param_value is not None:
                 operation_kwargs[param_name] = param_value

--- a/congress_api/features/buckets/amendments/api.py
+++ b/congress_api/features/buckets/amendments/api.py
@@ -177,9 +177,11 @@ async def search_amendments(
         if toDateTime is not None:
             api_params['toDateTime'] = toDateTime
 
-        # If keywords provided, add as query parameter for Congress.gov API
+        # Keyword filtering is CLIENT-SIDE: the /amendment endpoint has no
+        # query parameter (a 'query' param would be silently ignored), so
+        # fetch the largest page the API allows and filter locally.
         if keywords:
-            api_params['query'] = keywords
+            api_params['limit'] = 250
 
         # Build endpoint - API-faithful approach
         endpoint = "/amendment"
@@ -203,11 +205,26 @@ async def search_amendments(
         amendments = AmendmentsDataProcessor.deduplicate_amendments(amendments)
         duplicates_removed = original_count - len(amendments)
 
+        fetched = len(amendments)
+        if keywords:
+            amendments = AmendmentsDataProcessor.filter_by_keywords(amendments, keywords, limit)
+            if not amendments:
+                scope = f" in Congress {congress}" if congress else ""
+                return (
+                    f"No match for '{keywords}' in the purposes or "
+                    f"descriptions of the {fetched} most recently updated "
+                    f"amendments{scope}.\n\n"
+                    "Note: this operation only filters recently updated "
+                    "amendments by purpose text -- it is not a full-text or "
+                    "historical search."
+                )
+
         # Apply pagination
         amendments = ResponseProcessor.paginate_results(amendments, limit)
 
         # Format results
-        title = f"Amendments Matching '{keywords}'" if keywords else "Congressional Amendments"
+        title = (f"Amendments Matching '{keywords}' (purpose filter over "
+                 f"the {fetched} most recently updated)") if keywords else "Congressional Amendments"
         return AmendmentsFormatter.format_amendments_list(
             amendments,
             title=title,

--- a/congress_api/features/buckets/bills/__init__.py
+++ b/congress_api/features/buckets/bills/__init__.py
@@ -35,7 +35,6 @@ from .api import (
     get_bill_cosponsors,
     get_bill_related_bills,
     get_bill_subjects,
-    get_bill_content,
 )
 
 # Define what gets imported with "from bills import *"
@@ -60,7 +59,6 @@ __all__ = [
     'get_bill_cosponsors',
     'get_bill_related_bills',
     'get_bill_subjects',
-    'get_bill_content',
 ]
 
 # Module metadata

--- a/congress_api/features/buckets/bills/api.py
+++ b/congress_api/features/buckets/bills/api.py
@@ -160,8 +160,9 @@ async def search_bills(
                 bill_type=bill_type
             )
 
-        # For keyword search, get more results to filter from
-        search_limit = min(limit * 5, 250)  # Get extra for keyword filtering
+        # Client-side filter: fetch the largest page the API allows so the
+        # keyword match sees as many recently-updated bills as possible.
+        search_limit = 250
 
         # Core API call
         response = await fetch_bill_data(
@@ -186,11 +187,25 @@ async def search_bills(
         # Apply keyword filtering
         filtered_bills = await BillsDataProcessor.filter_by_keywords(bills, keywords, limit)
 
+        if not filtered_bills:
+            scope = f" in Congress {congress}" if congress else ""
+            return (
+                f"No match for '{keywords}' in the titles or policy areas of "
+                f"the {len(bills)} most recently updated bills{scope}.\n\n"
+                "Note: this operation only filters recently updated bills by "
+                "title/policy area -- it is not a full-text or historical "
+                "search. For text inside a bill use the search_bill_text "
+                "tool; for subject browsing use get_bill_subjects."
+            )
+
         # Update response with filtered bills
         response["bills"] = filtered_bills
 
         # Format and return
-        return BillsFormatter.format_bills_list(response, f"Bills matching '{keywords}'")
+        return BillsFormatter.format_bills_list(
+            response,
+            f"Bills matching '{keywords}' (title/policy-area filter over "
+            f"the {len(bills)} most recently updated)")
 
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
@@ -696,33 +711,6 @@ async def get_bill_titles(
     except Exception as e:
         logger.error(f"Error in get_bill_titles: {str(e)}")
         error_response = CommonErrors.api_server_error("get_bill_titles")
-        return format_error_response(error_response)
-
-
-async def get_bill_content(
-    ctx: Context,
-    congress: int,
-    bill_type: str,
-    bill_number: int,
-    chunk_number: Optional[int] = None,
-    chunk_size: int = 5000
-) -> str:
-    """Get content for a specific bill with chunking support."""
-    try:
-        # Real content-chunking (fetching a specific `version`'s full text and
-        # paging it via chunk_number/chunk_size) isn't implemented yet, so this
-        # delegates to get_bill_text_versions and ignores chunk_number/chunk_size
-        # entirely. `version` isn't even accepted here (schema/impl audit
-        # allowlist: scripts/audit_tool_schemas.py) -- accepting it and then
-        # ignoring it would be worse than the current hard rejection. Follow-up:
-        # implement real chunked content fetching and wire all three through.
-        return await get_bill_text_versions(ctx, congress, bill_type, bill_number)
-
-    except CongressionalAPIError as e:
-        return format_error_response(e.error_response)
-    except Exception as e:
-        logger.error(f"Error in get_bill_content: {str(e)}")
-        error_response = CommonErrors.api_server_error("get_bill_content")
         return format_error_response(error_response)
 
 

--- a/congress_api/features/buckets/research_and_professional.py
+++ b/congress_api/features/buckets/research_and_professional.py
@@ -81,13 +81,6 @@ async def route_research_and_professional_operation(ctx: Context, operation: str
         raw_response = await search_crs_reports(ctx, **kwargs)
         return _convert_to_structured_response(raw_response, operation)
 
-    # Future professional analytics operations
-    elif operation == "get_congress_statistics":
-        # Placeholder for future implementation
-        raise ToolError("Congress statistics analysis feature coming soon - contact support for early access")
-    elif operation == "get_legislative_analysis":
-        # Placeholder for future implementation
-        raise ToolError("Advanced legislative analysis feature coming soon - contact support for early access")
 
     else:
         raise ToolError(f"Unknown operation: {operation}")
@@ -120,10 +113,9 @@ async def research_and_professional(
     • get_congress_info_enhanced - Advanced analytics with detailed insights
     • search_congresses - Historical Congress search with trend analysis
 
-    PROFESSIONAL RESEARCH (3 operations):
-    • search_crs_reports - Congressional Research Service report search
-    • get_congress_statistics - Statistical analysis across Congresses
-    • get_legislative_analysis - Advanced legislative trend analysis
+    PROFESSIONAL RESEARCH (1 operation):
+    • search_crs_reports - CRS reports: exact report_number lookup, or a
+      title filter over the 250 most recently updated reports (not full-text)
 
     Key params: operation, congress, keywords, report_number, start_year, end_year
     Returns professional-grade research data with enhanced analytics and historical insights.

--- a/congress_api/features/buckets/voting_and_nominations.py
+++ b/congress_api/features/buckets/voting_and_nominations.py
@@ -22,7 +22,7 @@ def _convert_to_structured_response(raw_response: str, operation: str) -> Voting
     try:
         kind, items = structured_items_of(raw_response)
         if items is not None:
-            votes, nominations = [], []
+            votes, nominations, generic = [], [], []
             if kind == "house_vote":
                 for v in items:
                     leg_type = v.get("legislationType") or ""
@@ -60,9 +60,12 @@ def _convert_to_structured_response(raw_response: str, operation: str) -> Voting
                         update_date=n.get("updateDate"),
                         url=n.get("url"),
                     ))
+            if kind not in ("house_vote", "nomination"):
+                generic = items
             return VotingNominationsResponse(
                 success=True, operation=operation, results_count=len(items),
-                votes=votes, nominations=nominations, summary=str(raw_response))
+                votes=votes, nominations=nominations, items=generic,
+                item_kind=kind, summary=str(raw_response))
 
         return VotingNominationsResponse(
             success=True, operation=operation,

--- a/congress_api/features/crs_reports.py
+++ b/congress_api/features/crs_reports.py
@@ -308,9 +308,10 @@ async def search_crs_reports(
                 text = f"Search Results - CRS Reports matching '{keywords}':\n\n" + "\n\n".join(formatted_reports)
                 return structured(text, "crs_report", deduplicated_reports)
             else:
+                fetched = len(data['CRSReports'])
                 return (
                     f"No CRS report with '{keywords}' in the title among "
-                    f"the {search_limit} most recently updated reports.\n\n"
+                    f"the {fetched} most recently updated reports.\n\n"
                     "Note: this operation only filters recent report "
                     "TITLES -- it is not a full-text search. Try broader or "
                     "different title words, or a specific report_number "

--- a/congress_api/features/crs_reports.py
+++ b/congress_api/features/crs_reports.py
@@ -260,7 +260,7 @@ async def search_crs_reports(
             return format_error_response(CommonErrors.invalid_parameter("keywords", "Please provide either 'keywords' for searching recent reports or 'report_number' for a specific report (e.g., 'R47175')"))
         
         # Option B: Keyword Search - search larger batch of recent reports
-        search_limit = min(250, max(sanitized_limit * 5, 50))  # Search more than requested to improve filtering
+        search_limit = 250  # largest page the API allows; title filter runs client-side
         params = {
             'format': 'json',
             'limit': search_limit
@@ -308,9 +308,16 @@ async def search_crs_reports(
                 text = f"Search Results - CRS Reports matching '{keywords}':\n\n" + "\n\n".join(formatted_reports)
                 return structured(text, "crs_report", deduplicated_reports)
             else:
-                return format_error_response(CommonErrors.data_not_found(f"No CRS reports found matching keywords: '{keywords}'"))
+                return (
+                    f"No CRS report with '{keywords}' in the title among "
+                    f"the {search_limit} most recently updated reports.\n\n"
+                    "Note: this operation only filters recent report "
+                    "TITLES -- it is not a full-text search. Try broader or "
+                    "different title words, or a specific report_number "
+                    "(e.g. 'R47175')."
+                )
         else:
-            return format_error_response(CommonErrors.data_not_found("No CRS reports available"))
+            return "No CRS reports returned by the API."
             
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)

--- a/congress_api/features/house_votes.py
+++ b/congress_api/features/house_votes.py
@@ -623,6 +623,76 @@ async def get_house_vote_details_enhanced(ctx: Context, congress: int, session: 
         return format_error_response(CommonErrors.general_error(f"Error getting enhanced vote details: {str(e)}", ["Try again in a few moments", "Check your vote parameters"]))
 
 # @require_paid_access
+
+async def _fetch_member_votes_xml(ctx, congress, session, vote_number):
+    """Resolve the Clerk XML URL via Congress.gov and fetch it.
+
+    Returns (xml_content, source_url, error_markdown); exactly one of
+    xml_content/error_markdown is set.
+    """
+    endpoint = f"house-vote/{congress}/{session}/{vote_number}"
+    data = await safe_congressional_request(endpoint, ctx, {"format": "json"},
+                                            endpoint_type='house-votes')
+    if "error" in data:
+        return None, None, format_error_response(
+            CommonErrors.api_server_error(endpoint, message=data['error']))
+    if 'houseRollCallVote' not in data:
+        return None, None, f"House vote {congress}-{session}-{vote_number} not found."
+    source_data_url = data['houseRollCallVote'].get('sourceDataURL')
+    if not source_data_url:
+        return None, None, (f"No XML member vote data URL available for House "
+                            f"vote {congress}-{session}-{vote_number}.")
+    import httpx
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        response = await client.get(source_data_url)
+    if response.status_code != 200:
+        return None, source_data_url, format_error_response(CommonErrors.api_server_error(
+            f"Failed to fetch XML content from House Clerk website: HTTP {response.status_code}"))
+    if "<!ENTITY" in response.text:
+        return None, source_data_url, format_error_response(CommonErrors.api_server_error(
+            "Rejected Clerk XML containing entity declarations"))
+    return response.text, source_data_url, None
+
+
+def parse_member_votes(xml_content):
+    """Parse a Clerk roll-call XML into (header_lines, member_items, tallies).
+
+    member_items: [{"name", "party", "state", "vote"}, ...] for every
+    recorded vote in the document.
+    """
+    import xml.etree.ElementTree as ET
+    root = ET.fromstring(xml_content)
+    meta = root.find('vote-metadata')
+
+    def _t(tag):
+        el = meta.find(tag) if meta is not None else None
+        return el.text if el is not None and el.text else 'N/A'
+
+    header = [
+        f"**Legislation**: {_t('legis-num')}",
+        f"**Question**: {_t('vote-question')}",
+        f"**Result**: {_t('vote-result')}",
+        f"**Date**: {_t('action-date')}",
+    ]
+    members = []
+    vote_data = root.find('vote-data')
+    if vote_data is not None:
+        for rv in vote_data.findall('recorded-vote'):
+            leg, vote = rv.find('legislator'), rv.find('vote')
+            if leg is None or vote is None:
+                continue
+            members.append({
+                "name": leg.text or leg.get('unaccented-name') or 'Unknown',
+                "party": leg.get('party', 'Unknown'),
+                "state": leg.get('state', 'Unknown'),
+                "vote": vote.text or 'Unknown',
+            })
+    tallies = {}
+    for m in members:
+        tallies[m["vote"]] = tallies.get(m["vote"], 0) + 1
+    return header, members, tallies
+
+
 async def get_house_vote_member_votes(ctx: Context, congress: int, session: int, vote_number: int) -> str:
     """Get information about how individual members voted on a specific House roll call vote.
     
@@ -646,39 +716,32 @@ async def get_house_vote_member_votes(ctx: Context, congress: int, session: int,
         return format_error_response(CommonErrors.invalid_parameter("vote_number", vote_number, "Must be a positive integer"))
     
     try:
-        # First get the vote details to find the XML URL
-        endpoint = f"house-vote/{congress}/{session}/{vote_number}"
-        params = {"format": "json"}
-        
-        logger.debug(f"Fetching house vote details to get XML URL for {congress}-{session}-{vote_number}")
-        
-        # Make the API request
-        data = await safe_congressional_request(endpoint, ctx, params, endpoint_type='house-votes')
-        
-        if "error" in data:
-            logger.error(f"Error fetching house vote details: {data['error']}")
-            return format_error_response(CommonErrors.api_server_error(endpoint, message=data['error']))
-        
-        # Check for the correct response key
-        if 'houseRollCallVote' not in data:
-            return f"House vote {congress}-{session}-{vote_number} not found."
-        
-        vote = data['houseRollCallVote']
-        source_data_url = vote.get('sourceDataURL')
-        
-        if not source_data_url:
-            return f"No XML member vote data URL available for House vote {congress}-{session}-{vote_number}."
-        
+        xml_content, source_url, error = await _fetch_member_votes_xml(
+            ctx, congress, session, vote_number)
+        if error is not None:
+            return error
+
+        header, members, tallies = parse_member_votes(xml_content)
+        if not members:
+            return (f"The Clerk XML for House vote {congress}-{session}-"
+                    f"{vote_number} contains no recorded member votes: {source_url}")
+
         lines = [
             f"# Member Votes - House Vote {congress}-{session}-{vote_number}",
             "",
-            f"**Source Data URL**: {source_data_url}",
+            *header,
+            f"**Source**: {source_url}",
             "",
-            "**Note**: Member vote data is available in XML format from the House Clerk's website.",
-            "This data contains detailed voting information for each member including their vote choice (Yes/No/Present/Not Voting)."
+            "## Tallies",
         ]
-        
-        return "\n".join(lines)
+        for choice, count in sorted(tallies.items(), key=lambda kv: -kv[1]):
+            lines.append(f"- **{choice}**: {count}")
+        lines += [
+            "",
+            f"All {len(members)} individual member votes (name, party, state, "
+            "vote) are included in this response's structured `items` field.",
+        ]
+        return structured("\n".join(lines), "member_vote", members)
         
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)

--- a/congress_api/features/house_votes.py
+++ b/congress_api/features/house_votes.py
@@ -642,6 +642,11 @@ async def _fetch_member_votes_xml(ctx, congress, session, vote_number):
     if not source_data_url:
         return None, None, (f"No XML member vote data URL available for House "
                             f"vote {congress}-{session}-{vote_number}.")
+    from urllib.parse import urlparse
+    host = urlparse(source_data_url).hostname or ''
+    if host != 'clerk.house.gov' and not host.endswith('.house.gov'):
+        return None, source_data_url, format_error_response(CommonErrors.api_server_error(
+            f"Refusing to fetch member-vote XML from unexpected host: {host}"))
     import httpx
     async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
         response = await client.get(source_data_url)
@@ -776,52 +781,14 @@ async def get_house_vote_member_votes_xml(ctx: Context, congress: int, session: 
         return format_error_response(CommonErrors.invalid_parameter("vote_number", vote_number, "Must be a positive integer"))
     
     try:
-        # First get the vote details to find the XML URL
-        endpoint = f"house-vote/{congress}/{session}/{vote_number}"
-        params = {"format": "json"}
-        
-        logger.debug(f"Fetching house vote details to get XML URL for {congress}-{session}-{vote_number}")
-        
-        # Make the API request
-        data = await safe_congressional_request(endpoint, ctx, params, endpoint_type='house-votes')
-        
-        if "error" in data:
-            logger.error(f"Error fetching house vote details: {data['error']}")
-            return format_error_response(CommonErrors.api_server_error(endpoint, message=data['error']))
-        
-        # Check for the correct response key
-        if 'houseRollCallVote' not in data:
-            return f"House vote {congress}-{session}-{vote_number} not found."
-        
-        vote = data['houseRollCallVote']
-        source_data_url = vote.get('sourceDataURL')
-        
-        if not source_data_url:
-            return f"No XML member vote data URL available for House vote {congress}-{session}-{vote_number}."
-        
-        # Fetch the actual XML content from the House Clerk's website
-        logger.debug(f"Fetching XML member vote data from URL: {source_data_url}")
-        
-        try:
-            import httpx
-            async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
-                response = await client.get(source_data_url)
-                if response.status_code == 200:
-                    xml_content = response.text
-                    
-                    # Parse and format the XML content
-                    return format_house_vote_xml_content(xml_content, source_data_url)
-                else:
-                    logger.error(f"Failed to fetch XML content: HTTP {response.status_code}")
-                    return format_error_response(CommonErrors.api_server_error(
-                        f"Failed to fetch XML content from House Clerk website: HTTP {response.status_code}"
-                    ))
-        except Exception as fetch_error:
-            logger.error(f"Error fetching XML content: {str(fetch_error)}")
-            return format_error_response(CommonErrors.api_server_error(
-                f"Failed to fetch XML content: {str(fetch_error)}"
-            ))
-        
+        xml_content, source_url, error = await _fetch_member_votes_xml(
+            ctx, congress, session, vote_number)
+        if error is not None:
+            return error
+
+        # Parse and format the XML content
+        return format_house_vote_xml_content(xml_content, source_url)
+
     except CongressionalAPIError as e:
         return format_error_response(e.error_response)
     except Exception as e:

--- a/congress_api/features/summaries.py
+++ b/congress_api/features/summaries.py
@@ -576,7 +576,7 @@ async def search_summaries(
             )
         
         # Process response with deduplication and cleaning
-        summaries = clean_summaries_response(data, limit=100)  # Get more for filtering
+        summaries = clean_summaries_response(data, limit=250)  # keep the whole fetched page for filtering
         
         if not summaries:
             upstream = (data.get("pagination") or {}).get("count")

--- a/congress_api/features/summaries.py
+++ b/congress_api/features/summaries.py
@@ -541,7 +541,7 @@ async def search_summaries(
         # Build API request parameters
         params = {
             # Increase the limit to get more results for filtering
-            "limit": min(100, limit * 5),  # Get more results but cap at 100
+            "limit": 250,  # largest page the API allows; keyword filter runs client-side
             "sort": sort
         }
         
@@ -591,7 +591,11 @@ async def search_summaries(
         if keywords:
             filtered_summaries = SummariesProcessor.filter_by_keywords(summaries, keywords)
             title = f"Bill Summaries Matching '{keywords}'"
-            empty_msg = f"No summaries found matching '{keywords}'."
+            empty_msg = (
+                f"No match for '{keywords}' in the {len(summaries)} most "
+                "recently updated summaries in the date window. Note: this "
+                "filters recent summaries client-side -- it is not a "
+                "full-text search.")
         else:
             filtered_summaries = summaries
             title = "Recent Bill Summaries"

--- a/congress_api/models/responses.py
+++ b/congress_api/models/responses.py
@@ -131,6 +131,11 @@ class VotingNominationsResponse(BaseResponse):
     results_count: int = Field(description="Number of items returned (equals the populated list's length)")
     votes: List[VoteSummary] = Field(default=[], description="Vote results")
     nominations: List[NominationSummary] = Field(default=[], description="Nomination results")
+    items: List[Dict[str, Any]] = Field(
+        default=[],
+        description="Results of other kinds (per-member votes), as parsed from the source data")
+    item_kind: Optional[str] = Field(
+        default=None, description="What `items` contains (member_vote, ...)")
     summary: str = Field(description="Human-readable summary of the results")
 
 # Records & Hearings Response

--- a/scripts/audit_tool_schemas.py
+++ b/scripts/audit_tool_schemas.py
@@ -48,12 +48,10 @@ Usage
                                                      # EXTRA/DROPPED finding
                                                      # is not in the allowlist
 
-Known, deliberately-unfixed exception
+Known, deliberately-unfixed exceptions
 --------------------------------------
-(UNUSED) are excluded from the failing set via ALLOWLIST below. Content
-get_bill_text_versions and ignores all three params. Accepting `version` and
-silently ignoring it would be worse than the current hard rejection, so it's
-left alone pending the real chunking implementation. See the comment on
+A small number of (tool, operation, param) triples are excluded from the
+failing set via the ALLOWLIST below; each entry carries its own comment.
 """
 from __future__ import annotations
 
@@ -81,10 +79,6 @@ IGNORED_PARAMS = {"ctx", "self"}
 # exceptions -- not bugs to fix, just not yet implemented. Keep this list
 # small and each entry commented with why.
 ALLOWLIST: Set[Tuple[str, str, str]] = {
-    # delegates to get_bill_text_versions and has no use for a specific
-    # version. Accepting the param and ignoring it would be worse than
-    # rejecting it outright. See congress_api/features/buckets/bills/api.py.
-
     # most_recent: get_committee_nominations keeps the same signature as its
     # sibling committee tools (get_committee_bills/reports/communications),
     # but the Senate nominations endpoint is already newest-first, so there's

--- a/scripts/audit_tool_schemas.py
+++ b/scripts/audit_tool_schemas.py
@@ -50,13 +50,10 @@ Usage
 
 Known, deliberately-unfixed exception
 --------------------------------------
-bills/get_bill_content's `version` (EXTRA) and `chunk_number`/`chunk_size`
 (UNUSED) are excluded from the failing set via ALLOWLIST below. Content
-chunking isn't implemented yet -- get_bill_content currently delegates to
 get_bill_text_versions and ignores all three params. Accepting `version` and
 silently ignoring it would be worse than the current hard rejection, so it's
 left alone pending the real chunking implementation. See the comment on
-get_bill_content in congress_api/features/buckets/bills/api.py.
 """
 from __future__ import annotations
 
@@ -84,13 +81,9 @@ IGNORED_PARAMS = {"ctx", "self"}
 # exceptions -- not bugs to fix, just not yet implemented. Keep this list
 # small and each entry commented with why.
 ALLOWLIST: Set[Tuple[str, str, str]] = {
-    # version: get_bill_content doesn't do real content-chunking yet; it
     # delegates to get_bill_text_versions and has no use for a specific
     # version. Accepting the param and ignoring it would be worse than
     # rejecting it outright. See congress_api/features/buckets/bills/api.py.
-    ("bills", "get_bill_content", "version"),          # EXTRA
-    ("bills", "get_bill_content", "chunk_number"),      # UNUSED
-    ("bills", "get_bill_content", "chunk_size"),        # UNUSED
 
     # most_recent: get_committee_nominations keeps the same signature as its
     # sibling committee tools (get_committee_bills/reports/communications),

--- a/tests/test_honest_search_and_ops.py
+++ b/tests/test_honest_search_and_ops.py
@@ -1,0 +1,200 @@
+"""Issues #54 (honest keyword search) and #56 (dead/link-only operations)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from mcp.server.mcpserver.exceptions import ToolError
+
+
+class FakeContext:
+    async def info(self, *_):
+        pass
+
+    async def error(self, *_):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# #56: removed operations
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_bill_content_is_gone():
+    from congress_api.features.bills_tool import route_bills_operation
+    with pytest.raises(ToolError, match="Unknown bills operation"):
+        await route_bills_operation(FakeContext(), "get_bill_content",
+                                    congress=119, bill_type="hr", bill_number=1)
+    import congress_api.features.buckets.bills as bills_pkg
+    assert not hasattr(bills_pkg, "get_bill_content")
+
+
+@pytest.mark.asyncio
+async def test_research_stub_operations_are_gone():
+    from congress_api.features.buckets.research_and_professional import (
+        route_research_and_professional_operation)
+    for op in ("get_congress_statistics", "get_legislative_analysis"):
+        with pytest.raises(ToolError, match="Unknown operation"):
+            await route_research_and_professional_operation(FakeContext(), op)
+
+
+def test_no_coming_soon_left_in_schema_docs():
+    import glob
+    root = os.path.join(os.path.dirname(os.path.dirname(__file__)), "congress_api")
+    hits = [f for f in glob.glob(os.path.join(root, "**", "*.py"), recursive=True)
+            if "coming soon" in open(f).read().lower()]
+    assert hits == []
+
+
+# ---------------------------------------------------------------------------
+# #56: get_house_vote_member_votes returns real per-member votes
+# ---------------------------------------------------------------------------
+
+_CLERK_XML = """<?xml version="1.0"?>
+<rollcall-vote>
+  <vote-metadata>
+    <congress>119</congress><session>1st</session><rollcall-num>100</rollcall-num>
+    <legis-num>H CON RES 14</legis-num>
+    <vote-question>On Motion to Concur</vote-question>
+    <vote-result>Passed</vote-result>
+    <action-date>10-Apr-2025</action-date>
+  </vote-metadata>
+  <vote-data>
+    <recorded-vote><legislator party="D" state="NY">Schumer</legislator><vote>Nay</vote></recorded-vote>
+    <recorded-vote><legislator party="R" state="TX">Cornyn</legislator><vote>Yea</vote></recorded-vote>
+    <recorded-vote><legislator party="R" state="LA">Johnson</legislator><vote>Yea</vote></recorded-vote>
+  </vote-data>
+</rollcall-vote>"""
+
+
+def test_parse_member_votes():
+    from congress_api.features.house_votes import parse_member_votes
+    header, members, tallies = parse_member_votes(_CLERK_XML)
+    assert len(members) == 3
+    assert members[0] == {"name": "Schumer", "party": "D", "state": "NY", "vote": "Nay"}
+    assert tallies == {"Yea": 2, "Nay": 1}
+    assert any("H CON RES 14" in h for h in header)
+
+
+@pytest.mark.asyncio
+async def test_member_votes_returns_structured_items():
+    from congress_api.features import house_votes as mod
+
+    async def fake_fetch(ctx, congress, session, vote_number):
+        return _CLERK_XML, "https://clerk.house.gov/evs/2025/roll100.xml", None
+
+    with patch.object(mod, "_fetch_member_votes_xml", fake_fetch):
+        out = await mod.get_house_vote_member_votes(FakeContext(), congress=119,
+                                                    session=1, vote_number=100)
+    assert "Tallies" in out and "**Yea**: 2" in out
+    assert out.item_kind == "member_vote"
+    assert len(out.structured_items) == 3
+    # through the bucket converter, members land in the generic items field
+    from congress_api.features.buckets.voting_and_nominations import (
+        _convert_to_structured_response)
+    resp = _convert_to_structured_response(out, "get_house_vote_member_votes")
+    assert resp.results_count == 3
+    assert resp.items[1]["vote"] == "Yea" and resp.item_kind == "member_vote"
+
+
+@pytest.mark.asyncio
+async def test_member_votes_rejects_entity_xml():
+    from congress_api.features import house_votes as mod
+    evil = '<?xml version="1.0"?><!DOCTYPE x [<!ENTITY a "b">]><rollcall-vote/>'
+
+    class FakeResp:
+        status_code = 200
+        text = evil
+
+    class FakeClient:
+        def __init__(self, *a, **k): ...
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url):
+            return FakeResp()
+
+    with patch.object(mod, "safe_congressional_request",
+                      AsyncMock(return_value={"houseRollCallVote": {"sourceDataURL": "http://x"}})), \
+            patch("httpx.AsyncClient", FakeClient):
+        out = await mod.get_house_vote_member_votes(FakeContext(), congress=119,
+                                                    session=1, vote_number=100)
+    assert "entity" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# #54: honest keyword search
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_search_bills_miss_names_window_and_alternative():
+    from congress_api.features.buckets.bills import api as mod
+    bills = [{"title": "Post Office Naming Act", "policyArea": {"name": "Government"},
+              "type": "HR", "number": str(i), "congress": 119} for i in range(30)]
+    with patch.object(mod, "fetch_bill_data", AsyncMock(return_value={"bills": bills})):
+        out = await mod.search_bills(FakeContext(), keywords="climate", congress=119, limit=5)
+    assert "No match for 'climate'" in out
+    assert "most recently updated bills" in out
+    assert "search_bill_text" in out
+
+
+@pytest.mark.asyncio
+async def test_search_bills_fetches_max_page():
+    from congress_api.features.buckets.bills import api as mod
+    mock = AsyncMock(return_value={"bills": []})
+    with patch.object(mod, "fetch_bill_data", mock):
+        await mod.search_bills(FakeContext(), keywords="x", limit=5)
+    assert mock.call_args.kwargs["limit"] == 250
+
+
+@pytest.mark.asyncio
+async def test_search_amendments_filters_client_side_and_drops_query_param():
+    from congress_api.features.buckets.amendments import api as mod
+    amendments = [
+        {"congress": 119, "type": "SAMDT", "number": 1, "purpose": "To increase defense spending",
+         "updateDate": "2026-01-02"},
+        {"congress": 119, "type": "SAMDT", "number": 2, "purpose": "To rename a post office",
+         "updateDate": "2026-01-01"},
+    ]
+    captured = {}
+
+    async def fake_request(endpoint, ctx, params, **kw):
+        captured.update(params)
+        return {"amendments": amendments}
+
+    with patch.object(mod.DefensiveAPIWrapper, "safe_api_request", side_effect=fake_request):
+        out = await mod.search_amendments(FakeContext(), keywords="defense", congress=119, limit=5)
+    assert "query" not in captured          # bogus API param no longer sent
+    assert captured["limit"] == 250          # max window fetched
+    assert "defense spending" in out and "post office" not in out.lower()
+    # count phrase reflects the filtered set, and title names the window
+    assert "purpose filter over the" in out
+
+
+@pytest.mark.asyncio
+async def test_search_amendments_miss_is_honest():
+    from congress_api.features.buckets.amendments import api as mod
+    amendments = [{"congress": 119, "type": "SAMDT", "number": 1,
+                   "purpose": "Unrelated", "updateDate": "2026-01-01"}]
+    with patch.object(mod.DefensiveAPIWrapper, "safe_api_request",
+                      AsyncMock(return_value={"amendments": amendments})):
+        out = await mod.search_amendments(FakeContext(), keywords="zebras", limit=5)
+    assert "No match for 'zebras'" in out and "not a full-text" in out
+
+
+@pytest.mark.asyncio
+async def test_crs_miss_message_not_doubled():
+    from congress_api.features import crs_reports as mod
+    with patch.object(mod, "safe_crs_reports_request",
+                      AsyncMock(return_value={"CRSReports": [
+                          {"title": "Something else", "id": "1"}]})):
+        out = await mod.search_crs_reports(FakeContext(), keywords="tariffs", limit=5)
+    assert "No No" not in out
+    assert "most recently updated reports" in out
+    assert "report_number" in out

--- a/tests/test_honest_search_and_ops.py
+++ b/tests/test_honest_search_and_ops.py
@@ -120,8 +120,10 @@ async def test_member_votes_rejects_entity_xml():
         async def get(self, url):
             return FakeResp()
 
+    vote = {"houseRollCallVote":
+            {"sourceDataURL": "https://clerk.house.gov/evs/2025/roll100.xml"}}
     with patch.object(mod, "safe_congressional_request",
-                      AsyncMock(return_value={"houseRollCallVote": {"sourceDataURL": "https://clerk.house.gov/evs/2025/roll100.xml"}})), \
+                      AsyncMock(return_value=vote)), \
             patch("httpx.AsyncClient", FakeClient):
         out = await mod.get_house_vote_member_votes(FakeContext(), congress=119,
                                                     session=1, vote_number=100)

--- a/tests/test_honest_search_and_ops.py
+++ b/tests/test_honest_search_and_ops.py
@@ -121,7 +121,7 @@ async def test_member_votes_rejects_entity_xml():
             return FakeResp()
 
     with patch.object(mod, "safe_congressional_request",
-                      AsyncMock(return_value={"houseRollCallVote": {"sourceDataURL": "http://x"}})), \
+                      AsyncMock(return_value={"houseRollCallVote": {"sourceDataURL": "https://clerk.house.gov/evs/2025/roll100.xml"}})), \
             patch("httpx.AsyncClient", FakeClient):
         out = await mod.get_house_vote_member_votes(FakeContext(), congress=119,
                                                     session=1, vote_number=100)
@@ -198,3 +198,32 @@ async def test_crs_miss_message_not_doubled():
     assert "No No" not in out
     assert "most recently updated reports" in out
     assert "report_number" in out
+
+
+@pytest.mark.asyncio
+async def test_search_summaries_keyword_window_is_not_truncated():
+    """The 250-row fetch must not be cut back down by the response cleaner."""
+    from congress_api.features import summaries as mod
+    fetch = AsyncMock(return_value={"summaries": [], "pagination": {"count": 0}})
+    cleaned = []
+
+    def fake_clean(data, limit):
+        cleaned.append(limit)
+        return []
+
+    with patch.object(mod, "safe_congressional_request", fetch), \
+            patch.object(mod, "clean_summaries_response", fake_clean):
+        await mod.search_summaries(FakeContext(), keywords="veterans", congress=119)
+    assert fetch.call_args.args[2]["limit"] == 250
+    assert cleaned == [250]
+
+
+@pytest.mark.asyncio
+async def test_member_votes_refuses_non_clerk_host():
+    from congress_api.features import house_votes as mod
+    with patch.object(mod, "safe_congressional_request",
+                      AsyncMock(return_value={"houseRollCallVote":
+                                              {"sourceDataURL": "https://evil.example.com/x.xml"}})):
+        out = await mod.get_house_vote_member_votes(FakeContext(), congress=119,
+                                                    session=1, vote_number=100)
+    assert "unexpected host" in out

--- a/tests/test_invoke_all_operations_with_defaults.py
+++ b/tests/test_invoke_all_operations_with_defaults.py
@@ -12,10 +12,8 @@ It would have caught both known bugs described in the schema-drift audit:
   default) -- masked in production by the tool's blanket except-and-return-
   an-error-object handling, which is exactly why this test checks `.success`
   on structured responses instead of only "did it raise".
-- bills/get_bill_content: TypeError on `version` when a caller supplies it.
   This operation is intentionally excluded here (ALLOWLIST in the audit
   script) since content-chunking isn't implemented yet; see the comment on
-  get_bill_content in congress_api/features/buckets/bills/api.py.
 
 The network is mocked at the httpx.AsyncClient.get level -- the one place
 every request path funnels through regardless of which of the many

--- a/tests/test_invoke_all_operations_with_defaults.py
+++ b/tests/test_invoke_all_operations_with_defaults.py
@@ -12,8 +12,6 @@ It would have caught both known bugs described in the schema-drift audit:
   default) -- masked in production by the tool's blanket except-and-return-
   an-error-object handling, which is exactly why this test checks `.success`
   on structured responses instead of only "did it raise".
-  This operation is intentionally excluded here (ALLOWLIST in the audit
-  script) since content-chunking isn't implemented yet; see the comment on
 
 The network is mocked at the httpx.AsyncClient.get level -- the one place
 every request path funnels through regardless of which of the many


### PR DESCRIPTION
Fixes [#54](https://github.com/amurshak/congressMCP/issues/54) and [#56](https://github.com/amurshak/congressMCP/issues/56) from the functional review.

## #54 — keyword "search" was a small hidden window
- `search_bills` / `search_crs_reports` / `search_summaries` / `search_amendments` now fetch the API's **maximum page (250)** before filtering, name the window in result titles, and return an honest miss message pointing at real alternatives (`search_bill_text`, `get_bill_subjects`, `report_number`).
- **`search_amendments` was mislabeled unfiltered data**: it sent a `query` param the `/amendment` endpoint ignores and applied no filtering at all. It now filters purpose/description client-side like the others.
- Fixed the doubled CRS message ("No No CRS reports found … found matching your search criteria").

## #56 — operations that promised more than they delivered
- **`bills.get_bill_content` removed** (router, exports, schema, audit allowlist) — it was an alias of `get_bill_text_versions` that ignored its chunk params; the tool description now points at the bill-text tools.
- **"coming soon – contact support" stubs removed** (`get_congress_statistics`, `get_legislative_analysis`).
- **`get_house_vote_member_votes` now returns real votes**: fetches and parses the House Clerk XML it used to only link to — markdown carries question/result/tallies, and all individual member votes (`{name, party, state, vote}`) ship in the structured `items` field (kind `member_vote`); entity-bearing XML is rejected.

## Verification
- `tests/test_honest_search_and_ops.py` (10 tests) + 221 related tests green; schema audit and `check_known_failures` clean; no file lints worse than master.
- Live over stdio: `search_bills("climate")` now **finds bills** (SJRES 113 — the old 25-bill window found none); `search_amendments("defense")` returns an honest miss naming the window; vote 119-1-100 parses **433 member votes** with tallies 216–214–3 (matches the official count); removed ops answer "Unknown operation".

Closes #54, closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)