### PR TITLE
PR #63 follow-ups: clean version_not_found, Py3.10 syntax fix, unused imports

### DIFF
--- a/congress_api/features/bill_text/service.py
+++ b/congress_api/features/bill_text/service.py
@@ -27,6 +27,7 @@ the parse and build. Each is null when that leg did not run.
 from __future__ import annotations
 
 import logging
+import re
 import time
 from dataclasses import dataclass, field, replace
 
@@ -35,6 +36,7 @@ from mcp.server.mcpserver import Context
 from . import trace
 from .cache import CacheSettings, Resolution
 from .client import (
+    VERSION_CODE_PATTERN,
     DOWNLOAD_SECONDS,
     BillTextError,
     ResolvedBillText,
@@ -116,6 +118,15 @@ class _Legs:
 
 
 async def load_bill_text(ctx: Context, congress: int, bill_type: str, number: int, version: str | None) -> LoadedBillText:
+    if version is not None and not re.fullmatch(VERSION_CODE_PATTERN, version.lower()):
+        # Reject before the cache layer sees it: package_filename() raises
+        # ValueError on such input, which two of the three tools would report
+        # as internal_error (reviewer finding on PR #63).
+        raise BillTextError(
+            "version_not_found",
+            f"'{version}' is not a bill text version code.",
+            None,
+            "Use a GPO version code such as 'ih', 'eh', 'rs' or 'enr', or omit version.")
     store = get_store()
     settings = store.settings if store is not None else CacheSettings.from_env()
     bill_type = bill_type.lower()

--- a/congress_api/features/bill_text/tools.py
+++ b/congress_api/features/bill_text/tools.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import functools
 import logging
-import re
 import time
 from typing import Any, Iterable
 
@@ -13,7 +12,7 @@ from mcp.server.mcpserver import Context
 from ...mcp_app import mcp
 from . import trace
 from .client import BillTextError, govinfo_details_url
-from .index import fts_literal, has_token, normalized_query, sqlite_supports_fts5
+from .index import has_token, normalized_query, sqlite_supports_fts5
 from .models import (
     AncestorNode,
     BillSectionResponse,

--- a/tests/corpus/f36_scan.py
+++ b/tests/corpus/f36_scan.py
@@ -227,6 +227,13 @@ def _dash_forms(records: list[dict], tier: str) -> dict[str, int]:
     return dict(sorted(forms.items()))
 
 
+
+def _esc_pipes(text):
+    """Escape Markdown table pipes. Kept out of the f-string expression:
+    a backslash there is 3.12-only syntax (PEP 701) and this repo's floor
+    is Python 3.10."""
+    return text.replace("|", "\\|")
+
 def render_markdown(report: dict) -> str:
     lines = [
         "# F36 measurement -- parenthetical P.L. / U.S.C.-note cites on the amendatory subject",
@@ -278,7 +285,7 @@ def render_markdown(report: dict) -> str:
         "| # | document | unit | parenthetical | context |",
         "|---:|---|---|---|---|",
         *[f"| {n} | {x['package_id']} | {x['section_id']} | `{x['text'][:70]}` | "
-          f"…{x['context'].replace('|', '\\|')}… |"
+          f"…{_esc_pipes(x['context'])}… |"
           for n, x in enumerate(report["precision_sample"], start=1)],
         "",
         "## Instances on the F36 bill and every strict/relaxed NO-ENTRY instance elsewhere",

--- a/tests/test_bill_text_cache.py
+++ b/tests/test_bill_text_cache.py
@@ -663,3 +663,33 @@ def test_clear_reports_files_it_could_not_remove(tmp_path, monkeypatch):
     assert result.removed_packages == 3
     assert any(f.startswith(f"A.v{cache.SCHEMA_VERSION}.db") for f in result.failed)
     assert (layout.packages_dir / f"A.v{cache.SCHEMA_VERSION}.db").exists()
+
+
+class TestMalformedVersionInput:
+    """PR #63 review follow-up: a malformed `version` must come back as
+    version_not_found on every tool, never internal_error ('server-side
+    bug') -- the cache layer's filename guard raises ValueError on such
+    input before any network fallback can classify it."""
+
+    @pytest.mark.anyio
+    async def test_all_three_tools_reject_malformed_version_cleanly(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CONGRESSMCP_CACHE_DIR", str(tmp_path))
+        from congress_api.features.bill_text import tools
+
+        class Ctx:
+            async def info(self, *_):
+                ...
+
+            async def error(self, *_):
+                ...
+
+        for fn, kwargs in (
+            (tools.search_bill_text, {"queries": ["x"]}),
+            (tools.get_bill_section, {"section_id": "S:1"}),
+            (tools.get_bill_toc, {}),
+        ):
+            out = await fn(Ctx(), congress=119, bill_type="s", number=1071,
+                           version="e nr!", **kwargs)
+            err = (out or {}).get("error") or {}
+            assert err.get("code") == "version_not_found", (fn.__name__, out)
+            assert "internal_error" not in str(out)

--- a/tests/test_bill_text_store.py
+++ b/tests/test_bill_text_store.py
@@ -20,7 +20,7 @@ import congress_api.features.bill_text.service as service_mod
 import congress_api.features.bill_text.tools as tools_mod
 from congress_api.features.bill_text import cache
 from congress_api.features.bill_text.client import ResolvedBillText, TextVersion
-from congress_api.features.bill_text.index import FTS_TABLE, PACKAGE_TABLES, BillTextIndex, load_parsed
+from congress_api.features.bill_text.index import PACKAGE_TABLES, BillTextIndex
 from congress_api.features.bill_text.parser import Segment, Unit, parse_bill_xml
 from congress_api.features.bill_text.service import LoadedBillText
 from congress_api.features.bill_text.store import PackageBuildError, PackageStore


### PR DESCRIPTION
The three items from the [merge review of #63](https://github.com/amurshak/congressMCP/pull/63#issuecomment-5399846165):

1. **Malformed `version` → clean error**: `get_bill_toc(version="e nr!")` returned `internal_error` ("server-side bug") because `package_filename()`'s `ValueError` escaped two of the three tools' handlers. `load_bill_text` now validates against `VERSION_CODE_PATTERN` up front and raises `version_not_found` with remediation. Live-verified; regression test covers all three tools.
2. **Python 3.10 floor**: `tests/corpus/f36_scan.py` used PEP 701 syntax (backslash in f-string expression) — green on CI's 3.12, `SyntaxError` on the declared `>=3.10` floor, breaking local collection. Hoisted into a helper.
3. Four F401 unused imports removed.

Verified: 418 related tests pass on the merged tree, schema audit clean, warm-cache call still 252 ms live, lint strictly better than the PR branch on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)