### PR TITLE
One error envelope for the whole server (spec §9)

### DIFF
--- a/congress_api/core/exceptions.py
+++ b/congress_api/core/exceptions.py
@@ -7,6 +7,8 @@ and debugging utilities across all APIs.
 
 import logging
 from typing import List, Optional, Dict, Any
+import json
+from urllib.parse import urlsplit, urlunsplit
 from dataclasses import dataclass
 from enum import Enum
 
@@ -36,41 +38,68 @@ class APIErrorResponse:
         if isinstance(self.error_type, ErrorType):
             self.error_type = self.error_type.value
 
-def format_error_response(error: APIErrorResponse) -> str:
+class ErrorText(str):
+    """The formatted error string, still carrying its typed APIErrorResponse.
+
+    Converters for structured (Pydantic) tools read `.error_response` to
+    populate the typed `error` field; str-returning tools emit the string
+    as-is. A plain-str consumer sees only the JSON envelope text.
     """
-    Format an APIErrorResponse into a user-friendly markdown string.
-    
-    Args:
-        error: The error response to format
-        
-    Returns:
-        Formatted error message string
+
+    error_response: "APIErrorResponse"
+
+    def __new__(cls, text: str, error_response: "APIErrorResponse"):
+        obj = super().__new__(cls, text)
+        obj.error_response = error_response
+        return obj
+
+
+def _strip_url_secrets(value):
+    """Spec section 9 (F22 rule): any URL reaching an error `detail` is
+    stripped to scheme+host+path -- query strings can carry the api_key or
+    signed redirect tokens."""
+    if isinstance(value, str) and "://" in value:
+        try:
+            parts = urlsplit(value)
+            if parts.scheme and parts.netloc:
+                return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+        except ValueError:
+            return value
+    return value
+
+
+def error_envelope(error: APIErrorResponse) -> dict:
+    """Section-9 error envelope dict for a typed error.
+
+    {"error": {"code", "message", "detail", "remediation"}} with a stable
+    lowercase code, secret-stripped detail, and the suggestions folded into
+    one actionable remediation string.
     """
-    # Start with the main error message
-    formatted = f"❌ **Error**: {error.message}\n\n"
-    
-    # Add error type and code for debugging
-    formatted += f"**Error Type**: {error.error_type.title()}\n"
-    formatted += f"**Error Code**: {error.error_code}\n\n"
-    
-    # Add suggestions if available
-    if error.suggestions:
-        formatted += "**Suggestions**:\n"
-        for i, suggestion in enumerate(error.suggestions, 1):
-            formatted += f"{i}. {suggestion}\n"
-        formatted += "\n"
-    
-    # Add additional details if available
+    detail = None
     if error.details:
-        formatted += "**Additional Details**:\n"
-        for key, value in error.details.items():
-            formatted += f"- **{key.title()}**: {value}\n"
-        formatted += "\n"
-    
-    # Add general help message
-    formatted += "💡 If you continue to experience issues, try simplifying your query or checking the parameter formats."
-    
-    return formatted
+        detail = {k: _strip_url_secrets(v) for k, v in error.details.items()
+                  if v is not None}
+        detail = detail or None
+    remediation = "; ".join(error.suggestions) if error.suggestions else None
+    return {
+        "error": {
+            "code": (error.error_code or "general_error").lower(),
+            "message": error.message,
+            "detail": detail,
+            "remediation": remediation,
+        }
+    }
+
+
+def format_error_response(error: APIErrorResponse) -> str:
+    """Render a typed error as the section-9 JSON envelope (one envelope
+    format for the whole server -- models parse structure, not prose).
+
+    Returns an ErrorText: a str whose `.error_response` lets the structured
+    converters rebuild the typed `error` field without re-parsing JSON.
+    """
+    return ErrorText(json.dumps(error_envelope(error), indent=2), error)
+
 
 class CongressionalAPIError(Exception):
     """Base exception for Congressional MCP API errors."""

--- a/congress_api/core/exceptions.py
+++ b/congress_api/core/exceptions.py
@@ -8,6 +8,7 @@ and debugging utilities across all APIs.
 import logging
 from typing import List, Optional, Dict, Any
 import json
+import re as _re_mod
 from urllib.parse import urlsplit, urlunsplit
 from dataclasses import dataclass
 from enum import Enum
@@ -54,6 +55,9 @@ class ErrorText(str):
         return obj
 
 
+_URL_RE = _re_mod.compile(r"https?://\S+")
+
+
 def _strip_url_secrets(value):
     """Spec section 9 (F22 rule): any URL reaching an error `detail` is
     stripped to scheme+host+path -- query strings can carry the api_key or
@@ -63,6 +67,8 @@ def _strip_url_secrets(value):
             parts = urlsplit(value)
             if parts.scheme and parts.netloc:
                 return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+            # URL embedded mid-sentence: strip the query of every match.
+            return _URL_RE.sub(lambda m: m.group(0).split("?", 1)[0].split("#", 1)[0], value)
         except ValueError:
             return value
     return value

--- a/congress_api/features/amendments_tool.py
+++ b/congress_api/features/amendments_tool.py
@@ -9,7 +9,7 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
-from ..core.exceptions import CongressionalAPIError
+from ..core.exceptions import CongressionalAPIError, format_error_response
 from ..mcp_app import mcp
 from ..core.operation_routing import validate_operation_kwargs
 
@@ -132,9 +132,9 @@ async def amendments(
         return raw_response
 
     except CongressionalAPIError as e:
-        # Typed Congress.gov error from a handler with no try/except of its own:
-        # surface the classification instead of a generic failure.
-        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
+        # Typed Congress.gov error from a handler with no try/except of its
+        # own: return the section-9 envelope instead of a ToolError string.
+        return format_error_response(e.error_response)
     except ToolError:
         # Re-raise ToolError as-is (preserves access control messages)
         raise

--- a/congress_api/features/bills_tool.py
+++ b/congress_api/features/bills_tool.py
@@ -9,7 +9,7 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
-from ..core.exceptions import CongressionalAPIError
+from ..core.exceptions import CongressionalAPIError, format_error_response
 from ..mcp_app import mcp
 from ..core.operation_routing import validate_operation_kwargs
 from ..utils.bill_parser import parse_bill_reference, validate_bill_params
@@ -199,9 +199,9 @@ async def bills(
         return raw_response
 
     except CongressionalAPIError as e:
-        # Typed Congress.gov error from a handler with no try/except of its own:
-        # surface the classification instead of a generic failure.
-        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
+        # Typed Congress.gov error from a handler with no try/except of its
+        # own: return the section-9 envelope instead of a ToolError string.
+        return format_error_response(e.error_response)
     except ToolError:
         # Re-raise ToolError as-is (preserves access control messages)
         raise

--- a/congress_api/features/bound_congressional_record.py
+++ b/congress_api/features/bound_congressional_record.py
@@ -343,8 +343,8 @@ async def search_bound_congressional_record(
         return format_error_response(e.error_response)
     except Exception as e:
         logger.error(f"Error in search_bound_congressional_record: {str(e)}")
-        # If it's already a formatted error, return it directly
-        if "❌ **Error**:" in str(e):
+        # If it's already a formatted section-9 envelope, return it directly
+        if '"error"' in str(e) and '"code"' in str(e):
             return str(e)
         
         # Otherwise, create a general error response

--- a/congress_api/features/buckets/committee_intelligence.py
+++ b/congress_api/features/buckets/committee_intelligence.py
@@ -9,10 +9,10 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
-from ...core.exceptions import CongressionalAPIError
+from ...core.exceptions import CongressionalAPIError, error_envelope, format_error_response
 from ...mcp_app import mcp
 from ...core.operation_routing import validate_operation_kwargs
-from ...models.responses import CommitteeIntelligenceResponse, CommitteeActivitySummary
+from ...models.responses import CommitteeIntelligenceResponse, CommitteeActivitySummary, ErrorInfo
 from ...utils.response_converters import _extract_result_count, structured_items_of
 
 logger = logging.getLogger(__name__)
@@ -20,6 +20,15 @@ logger = logging.getLogger(__name__)
 def _convert_to_structured_response(raw_response: str, operation: str) -> CommitteeIntelligenceResponse:
     """Build the structured response; typed lists come from the impl's real items."""
     try:
+        typed_error = getattr(raw_response, "error_response", None)
+        if typed_error is not None:
+            payload = error_envelope(typed_error)["error"]
+            return CommitteeIntelligenceResponse(
+                success=False, operation=operation,
+                error=ErrorInfo(**payload), results_count=0,
+                activities=[],
+                summary=f"{payload['code']}: {payload['message']}")
+
         kind, items = structured_items_of(raw_response)
         if items is not None:
             activities = []
@@ -244,9 +253,9 @@ async def committee_intelligence(
         return await route_committee_intelligence_operation(ctx, operation, **operation_kwargs)
 
     except CongressionalAPIError as e:
-        # Typed Congress.gov error from a handler with no try/except of its own:
-        # surface the classification instead of a generic failure.
-        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
+        # Typed Congress.gov error from a handler with no try/except of its
+        # own: return the model carrying the section-9 envelope.
+        return _convert_to_structured_response(format_error_response(e.error_response), operation)
     except ToolError:
         raise
     except Exception as e:

--- a/congress_api/features/buckets/laws.py
+++ b/congress_api/features/buckets/laws.py
@@ -15,7 +15,7 @@ from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
 
-from ...core.exceptions import CongressionalAPIError
+from ...core.exceptions import CongressionalAPIError, format_error_response
 from ...mcp_app import mcp
 from ...core.api_wrapper import safe_congressional_request
 from ...core.operation_routing import validate_operation_kwargs
@@ -166,9 +166,9 @@ async def laws(
         }
         return await route_laws_operation(ctx, operation, **kwargs)
     except CongressionalAPIError as e:
-        # Typed Congress.gov error from a handler with no try/except of its own:
-        # surface the classification instead of a generic failure.
-        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
+        # Typed Congress.gov error from a handler with no try/except of its
+        # own: return the section-9 envelope instead of a ToolError string.
+        return format_error_response(e.error_response)
     except ToolError:
         raise
     except Exception as e:

--- a/congress_api/features/buckets/records_and_hearings.py
+++ b/congress_api/features/buckets/records_and_hearings.py
@@ -9,10 +9,10 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
-from ...core.exceptions import CongressionalAPIError
+from ...core.exceptions import CongressionalAPIError, error_envelope, format_error_response
 from ...mcp_app import mcp
 from ...core.operation_routing import validate_operation_kwargs
-from ...models.responses import RecordsHearingsResponse, HearingSummary, RecordSummary
+from ...models.responses import RecordsHearingsResponse, HearingSummary, RecordSummary, ErrorInfo
 from ...utils.response_converters import _extract_result_count, _int_or_none, structured_items_of
 
 logger = logging.getLogger(__name__)
@@ -20,6 +20,15 @@ logger = logging.getLogger(__name__)
 def _convert_to_structured_response(raw_response: str, operation: str) -> RecordsHearingsResponse:
     """Build the structured response; typed lists come from the impl's real items."""
     try:
+        typed_error = getattr(raw_response, "error_response", None)
+        if typed_error is not None:
+            payload = error_envelope(typed_error)["error"]
+            return RecordsHearingsResponse(
+                success=False, operation=operation,
+                error=ErrorInfo(**payload), results_count=0,
+                hearings=[], records=[],
+                summary=f"{payload['code']}: {payload['message']}")
+
         kind, items = structured_items_of(raw_response)
         if items is not None:
             hearings, records, generic = [], [], []
@@ -239,9 +248,9 @@ async def records_and_hearings(
         return await route_records_and_hearings_operation(ctx, operation, **operation_kwargs)
 
     except CongressionalAPIError as e:
-        # Typed Congress.gov error from a handler with no try/except of its own:
-        # surface the classification instead of a generic failure.
-        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
+        # Typed Congress.gov error from a handler with no try/except of its
+        # own: return the model carrying the section-9 envelope.
+        return _convert_to_structured_response(format_error_response(e.error_response), operation)
     except ToolError:
         raise
     except Exception as e:

--- a/congress_api/features/buckets/research_and_professional.py
+++ b/congress_api/features/buckets/research_and_professional.py
@@ -9,10 +9,10 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
-from ...core.exceptions import CongressionalAPIError
+from ...core.exceptions import CongressionalAPIError, error_envelope, format_error_response
 from ...mcp_app import mcp
 from ...core.operation_routing import validate_operation_kwargs
-from ...models.responses import ResearchProfessionalResponse, ResearchSummary
+from ...models.responses import ResearchProfessionalResponse, ResearchSummary, ErrorInfo
 from ...utils.response_converters import _extract_result_count, structured_items_of
 
 logger = logging.getLogger(__name__)
@@ -20,6 +20,15 @@ logger = logging.getLogger(__name__)
 def _convert_to_structured_response(raw_response: str, operation: str) -> ResearchProfessionalResponse:
     """Build the structured response; typed lists come from the impl's real items."""
     try:
+        typed_error = getattr(raw_response, "error_response", None)
+        if typed_error is not None:
+            payload = error_envelope(typed_error)["error"]
+            return ResearchProfessionalResponse(
+                success=False, operation=operation,
+                error=ErrorInfo(**payload), results_count=0,
+                research_materials=[],
+                summary=f"{payload['code']}: {payload['message']}")
+
         kind, items = structured_items_of(raw_response)
         if items is not None:
             materials = []
@@ -145,9 +154,9 @@ async def research_and_professional(
         return await route_research_and_professional_operation(ctx, operation, **operation_kwargs)
 
     except CongressionalAPIError as e:
-        # Typed Congress.gov error from a handler with no try/except of its own:
-        # surface the classification instead of a generic failure.
-        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
+        # Typed Congress.gov error from a handler with no try/except of its
+        # own: return the model carrying the section-9 envelope.
+        return _convert_to_structured_response(format_error_response(e.error_response), operation)
     except ToolError:
         raise
     except Exception as e:

--- a/congress_api/features/buckets/voting_and_nominations.py
+++ b/congress_api/features/buckets/voting_and_nominations.py
@@ -9,10 +9,10 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
-from ...core.exceptions import CongressionalAPIError
+from ...core.exceptions import CongressionalAPIError, error_envelope, format_error_response
 from ...mcp_app import mcp
 from ...core.operation_routing import validate_operation_kwargs
-from ...models.responses import VotingNominationsResponse, VoteSummary, NominationSummary
+from ...models.responses import VotingNominationsResponse, VoteSummary, NominationSummary, ErrorInfo
 from ...utils.response_converters import _extract_result_count, structured_items_of
 
 logger = logging.getLogger(__name__)
@@ -20,6 +20,15 @@ logger = logging.getLogger(__name__)
 def _convert_to_structured_response(raw_response: str, operation: str) -> VotingNominationsResponse:
     """Build the structured response; typed lists come from the impl's real items."""
     try:
+        typed_error = getattr(raw_response, "error_response", None)
+        if typed_error is not None:
+            payload = error_envelope(typed_error)["error"]
+            return VotingNominationsResponse(
+                success=False, operation=operation,
+                error=ErrorInfo(**payload), results_count=0,
+                votes=[], nominations=[],
+                summary=f"{payload['code']}: {payload['message']}")
+
         kind, items = structured_items_of(raw_response)
         if items is not None:
             votes, nominations, generic = [], [], []
@@ -217,9 +226,9 @@ async def voting_and_nominations(
         return await route_voting_and_nominations_operation(ctx, operation, **operation_kwargs)
 
     except CongressionalAPIError as e:
-        # Typed Congress.gov error from a handler with no try/except of its own:
-        # surface the classification instead of a generic failure.
-        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
+        # Typed Congress.gov error from a handler with no try/except of its
+        # own: return the model carrying the section-9 envelope.
+        return _convert_to_structured_response(format_error_response(e.error_response), operation)
     except ToolError:
         raise
     except Exception as e:

--- a/congress_api/features/members_committees_tools.py
+++ b/congress_api/features/members_committees_tools.py
@@ -9,7 +9,7 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from ..mcp_app import mcp
-from ..models.responses import MembersCommitteesResponse
+from ..models.responses import MembersCommitteesResponse, ErrorInfo
 from ..utils.response_converters import convert_members_committees_response
 
 logger = logging.getLogger(__name__)
@@ -67,11 +67,14 @@ async def search_members(
         return MembersCommitteesResponse(
             success=False,
             operation="search_members",
+            error=ErrorInfo(code="internal_error",
+                            message=f"search_members failed unexpectedly: {str(e)}",
+                            remediation="Server-side bug; see the MCP server log."),
             results_count=0,
             members=[],
             committees=[],
-            summary=f"Error searching members: {str(e)}",
-            context="Search members operation failed"
+            summary=f"internal_error: {str(e)}",
+            context="Failed search_members operation",
         )
 
 @mcp.tool(
@@ -101,11 +104,14 @@ async def get_member_details(
         return MembersCommitteesResponse(
             success=False,
             operation="get_member_details",
+            error=ErrorInfo(code="internal_error",
+                            message=f"get_member_details failed unexpectedly: {str(e)}",
+                            remediation="Server-side bug; see the MCP server log."),
             results_count=0,
             members=[],
             committees=[],
-            summary=f"Error retrieving member details: {str(e)}",
-            context=f"Get details for member {bioguide_id} failed"
+            summary=f"internal_error: {str(e)}",
+            context="Failed get_member_details operation",
         )
 
 @mcp.tool(
@@ -144,11 +150,14 @@ async def get_member_sponsored_legislation(
         return MembersCommitteesResponse(
             success=False,
             operation="get_member_sponsored_legislation",
+            error=ErrorInfo(code="internal_error",
+                            message=f"get_member_sponsored_legislation failed unexpectedly: {str(e)}",
+                            remediation="Server-side bug; see the MCP server log."),
             results_count=0,
             members=[],
             committees=[],
-            summary=f"Error retrieving sponsored legislation: {str(e)}",
-            context=f"Get sponsored legislation for member {bioguide_id} failed"
+            summary=f"internal_error: {str(e)}",
+            context="Failed get_member_sponsored_legislation operation",
         )
 
 @mcp.tool(
@@ -187,11 +196,14 @@ async def get_member_cosponsored_legislation(
         return MembersCommitteesResponse(
             success=False,
             operation="get_member_cosponsored_legislation",
+            error=ErrorInfo(code="internal_error",
+                            message=f"get_member_cosponsored_legislation failed unexpectedly: {str(e)}",
+                            remediation="Server-side bug; see the MCP server log."),
             results_count=0,
             members=[],
             committees=[],
-            summary=f"Error retrieving cosponsored legislation: {str(e)}",
-            context=f"Get cosponsored legislation for member {bioguide_id} failed"
+            summary=f"internal_error: {str(e)}",
+            context="Failed get_member_cosponsored_legislation operation",
         )
 
 @mcp.tool(
@@ -230,11 +242,14 @@ async def get_members_by_congress(
         return MembersCommitteesResponse(
             success=False,
             operation="get_members_by_congress",
+            error=ErrorInfo(code="internal_error",
+                            message=f"get_members_by_congress failed unexpectedly: {str(e)}",
+                            remediation="Server-side bug; see the MCP server log."),
             results_count=0,
             members=[],
             committees=[],
-            summary=f"Error retrieving members by congress: {str(e)}",
-            context=f"Get members for Congress {congress} failed"
+            summary=f"internal_error: {str(e)}",
+            context="Failed get_members_by_congress operation",
         )
 
 @mcp.tool(
@@ -273,11 +288,14 @@ async def get_members_by_state(
         return MembersCommitteesResponse(
             success=False,
             operation="get_members_by_state",
+            error=ErrorInfo(code="internal_error",
+                            message=f"get_members_by_state failed unexpectedly: {str(e)}",
+                            remediation="Server-side bug; see the MCP server log."),
             results_count=0,
             members=[],
             committees=[],
-            summary=f"Error retrieving members by state: {str(e)}",
-            context=f"Get members for state {state_code} failed"
+            summary=f"internal_error: {str(e)}",
+            context="Failed get_members_by_state operation",
         )
 
 @mcp.tool(
@@ -316,11 +334,14 @@ async def get_members_by_district(
         return MembersCommitteesResponse(
             success=False,
             operation="get_members_by_district",
+            error=ErrorInfo(code="internal_error",
+                            message=f"get_members_by_district failed unexpectedly: {str(e)}",
+                            remediation="Server-side bug; see the MCP server log."),
             results_count=0,
             members=[],
             committees=[],
-            summary=f"Error retrieving member by district: {str(e)}",
-            context=f"Get member for {state_code}-{district} failed"
+            summary=f"internal_error: {str(e)}",
+            context="Failed get_members_by_district operation",
         )
 
 @mcp.tool(
@@ -362,11 +383,14 @@ async def get_members_by_congress_state_district(
         return MembersCommitteesResponse(
             success=False,
             operation="get_members_by_congress_state_district",
+            error=ErrorInfo(code="internal_error",
+                            message=f"get_members_by_congress_state_district failed unexpectedly: {str(e)}",
+                            remediation="Server-side bug; see the MCP server log."),
             results_count=0,
             members=[],
             committees=[],
-            summary=f"Error retrieving member by congress/state/district: {str(e)}",
-            context=f"Get member for Congress {congress}, {state_code}-{district} failed"
+            summary=f"internal_error: {str(e)}",
+            context="Failed get_members_by_congress_state_district operation",
         )
 
 # Committee Tools
@@ -414,11 +438,14 @@ async def search_committees(
         return MembersCommitteesResponse(
             success=False,
             operation="search_committees",
+            error=ErrorInfo(code="internal_error",
+                            message=f"search_committees failed unexpectedly: {str(e)}",
+                            remediation="Server-side bug; see the MCP server log."),
             results_count=0,
             members=[],
             committees=[],
-            summary=f"Error searching committees: {str(e)}",
-            context="Search committees operation failed"
+            summary=f"internal_error: {str(e)}",
+            context="Failed search_committees operation",
         )
 
 @mcp.tool(
@@ -465,11 +492,14 @@ async def get_committee_bills(
         return MembersCommitteesResponse(
             success=False,
             operation="get_committee_bills",
+            error=ErrorInfo(code="internal_error",
+                            message=f"get_committee_bills failed unexpectedly: {str(e)}",
+                            remediation="Server-side bug; see the MCP server log."),
             results_count=0,
             members=[],
             committees=[],
-            summary=f"Error retrieving committee bills: {str(e)}",
-            context=f"Get bills for committee {committee_code} failed"
+            summary=f"internal_error: {str(e)}",
+            context="Failed get_committee_bills operation",
         )
 
 @mcp.tool(
@@ -515,11 +545,14 @@ async def get_committee_reports(
         return MembersCommitteesResponse(
             success=False,
             operation="get_committee_reports",
+            error=ErrorInfo(code="internal_error",
+                            message=f"get_committee_reports failed unexpectedly: {str(e)}",
+                            remediation="Server-side bug; see the MCP server log."),
             results_count=0,
             members=[],
             committees=[],
-            summary=f"Error retrieving committee reports: {str(e)}",
-            context=f"Get reports for committee {committee_code} failed"
+            summary=f"internal_error: {str(e)}",
+            context="Failed get_committee_reports operation",
         )
 
 @mcp.tool(
@@ -565,11 +598,14 @@ async def get_committee_communications(
         return MembersCommitteesResponse(
             success=False,
             operation="get_committee_communications",
+            error=ErrorInfo(code="internal_error",
+                            message=f"get_committee_communications failed unexpectedly: {str(e)}",
+                            remediation="Server-side bug; see the MCP server log."),
             results_count=0,
             members=[],
             committees=[],
-            summary=f"Error retrieving committee communications: {str(e)}",
-            context=f"Get communications for committee {committee_code} failed"
+            summary=f"internal_error: {str(e)}",
+            context="Failed get_committee_communications operation",
         )
 
 @mcp.tool(
@@ -611,9 +647,12 @@ async def get_committee_nominations(
         return MembersCommitteesResponse(
             success=False,
             operation="get_committee_nominations",
+            error=ErrorInfo(code="internal_error",
+                            message=f"get_committee_nominations failed unexpectedly: {str(e)}",
+                            remediation="Server-side bug; see the MCP server log."),
             results_count=0,
             members=[],
             committees=[],
-            summary=f"Error retrieving committee nominations: {str(e)}",
-            context=f"Get nominations for committee {committee_code} failed"
+            summary=f"internal_error: {str(e)}",
+            context="Failed get_committee_nominations operation",
         )

--- a/congress_api/features/treaties_and_summaries_tool.py
+++ b/congress_api/features/treaties_and_summaries_tool.py
@@ -9,7 +9,7 @@ import logging
 from typing import Optional
 from mcp.server.mcpserver import Context
 from mcp.server.mcpserver.exceptions import ToolError
-from ..core.exceptions import CongressionalAPIError
+from ..core.exceptions import CongressionalAPIError, format_error_response
 from ..mcp_app import mcp
 from ..core.operation_routing import validate_operation_kwargs
 
@@ -129,9 +129,9 @@ async def treaties_and_summaries(
         return raw_response
 
     except CongressionalAPIError as e:
-        # Typed Congress.gov error from a handler with no try/except of its own:
-        # surface the classification instead of a generic failure.
-        raise ToolError(f"{e.error_response.error_code}: {e.error_response.message}")
+        # Typed Congress.gov error from a handler with no try/except of its
+        # own: return the section-9 envelope instead of a ToolError string.
+        return format_error_response(e.error_response)
     except ToolError:
         # Re-raise ToolError as-is (preserves access control messages)
         raise

--- a/congress_api/models/responses.py
+++ b/congress_api/models/responses.py
@@ -14,10 +14,23 @@ from typing import List, Optional, Dict, Any, Union
 from pydantic import BaseModel, Field
 
 # Base Response Models
+class ErrorInfo(BaseModel):
+    """Section-9 error payload: stable code, human message, secret-safe
+    detail, actionable remediation. Mirrors the bill-text tools' envelope
+    (documentation/fulltext/04-tools-responses.md section 9)."""
+    code: str = Field(description="Stable machine-readable error code (lowercase)")
+    message: str = Field(description="What went wrong")
+    detail: Optional[Dict[str, Any]] = Field(default=None, description="Structured context; never carries secrets")
+    remediation: Optional[str] = Field(default=None, description="What the caller should do about it")
+
+
 class BaseResponse(BaseModel):
     """Base response model with common fields."""
     success: bool = Field(description="Whether the operation was successful")
     operation: str = Field(description="The operation that was performed")
+    error: Optional[ErrorInfo] = Field(
+        default=None,
+        description="Present when success is false: the section-9 error envelope")
 
 class ErrorResponse(BaseResponse):
     """Error response model."""

--- a/congress_api/utils/response_converters.py
+++ b/congress_api/utils/response_converters.py
@@ -14,8 +14,10 @@ import logging
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
+from ..core.exceptions import error_envelope
 from ..models.responses import (
     CommitteeSummary,
+    ErrorInfo,
     MemberSummary,
     MembersCommitteesResponse,
 )
@@ -172,6 +174,18 @@ def convert_members_committees_response(raw_response: str, operation: str) -> Me
     `item_kind`.
     """
     try:
+        typed_error = getattr(raw_response, "error_response", None)
+        if typed_error is not None:
+            payload = error_envelope(typed_error)["error"]
+            return MembersCommitteesResponse(
+                success=False,
+                operation=operation,
+                error=ErrorInfo(**payload),
+                results_count=0,
+                summary=f"{payload['code']}: {payload['message']}",
+                context=f"Failed {operation} operation",
+            )
+
         kind, items = structured_items_of(raw_response)
         if items is not None:
             members: List[MemberSummary] = []

--- a/tests/test_invoke_all_operations_with_defaults.py
+++ b/tests/test_invoke_all_operations_with_defaults.py
@@ -176,7 +176,12 @@ async def test_operation_invocable_with_schema_defaults(tool_name, operation, to
                 f"{tool_name}::{operation} failed without a typed error: "
                 f"{getattr(result, 'summary', result)}"
             )
-            assert err.code != "internal_error", (
+            # With an always-healthy mocked network, none of these codes are
+            # legitimate: internal_error is a crash by definition, and
+            # server_error/general_* only arise from handler-local generic
+            # excepts swallowing a crash (the network cannot have failed).
+            assert err.code not in ("internal_error", "server_error",
+                                    "general_error", "general_api_failure"), (
                 f"{tool_name}::{operation} crashed: {err.message}"
             )
     elif isinstance(result, str) and result.lstrip().startswith("{"):
@@ -184,7 +189,8 @@ async def test_operation_invocable_with_schema_defaults(tool_name, operation, to
             payload = _json.loads(result).get("error") or {}
         except ValueError:
             payload = {}
-        assert payload.get("code") != "internal_error", (
+        assert payload.get("code") not in ("internal_error", "server_error",
+                                           "general_error", "general_api_failure"), (
             f"{tool_name}::{operation} crashed: {payload.get('message')}"
         )
 

--- a/tests/test_invoke_all_operations_with_defaults.py
+++ b/tests/test_invoke_all_operations_with_defaults.py
@@ -155,18 +155,37 @@ _OPERATIONS = _list_operations()
     ids=[f"{t}::{o}" for t, o, _, _ in _OPERATIONS],
 )
 async def test_operation_invocable_with_schema_defaults(tool_name, operation, tool_fn, kwargs):
-    """Every operation must run its full call chain without raising, and
-    without reporting success=False on a structured response -- with an
-    always-empty-but-valid mocked network layer, a False/raised result can
-    only come from a code bug, not real "no data" business logic."""
+    """Every operation must run its full call chain without raising, and never
+    produce an internal_error -- with an always-empty-but-valid mocked network
+    layer, internal_error (or an untyped failure) can only come from a code
+    bug (a signature mismatch, a crash in the handler body), not business
+    logic. Honest domain errors ARE allowed now that the section-9 envelope
+    surfaces them: empty mocked data legitimately yields data_not_found, and
+    schema defaults legitimately violate some operations' parameter rules
+    (invalid_parameter). Before the envelope work those cases hid behind
+    success=True markdown, which is what the old assertion checked."""
+    import json as _json
     ctx = _make_fake_ctx()
     with patch.object(httpx.AsyncClient, "get", return_value=_FakeResponse()):
         result = await tool_fn(ctx, **kwargs)
 
     if hasattr(result, "success"):
-        assert result.success is True, (
-            f"{tool_name}::{operation} returned success=False: "
-            f"{getattr(result, 'summary', result)}"
+        if result.success is False:
+            err = getattr(result, "error", None)
+            assert err is not None, (
+                f"{tool_name}::{operation} failed without a typed error: "
+                f"{getattr(result, 'summary', result)}"
+            )
+            assert err.code != "internal_error", (
+                f"{tool_name}::{operation} crashed: {err.message}"
+            )
+    elif isinstance(result, str) and result.lstrip().startswith("{"):
+        try:
+            payload = _json.loads(result).get("error") or {}
+        except ValueError:
+            payload = {}
+        assert payload.get("code") != "internal_error", (
+            f"{tool_name}::{operation} crashed: {payload.get('message')}"
         )
 
 

--- a/tests/test_review_p1_fixes.py
+++ b/tests/test_review_p1_fixes.py
@@ -194,7 +194,7 @@ async def test_get_treaty_text_not_found_returns_str():
                       AsyncMock(return_value={})):
         out = await mod.get_treaty_text(FakeContext(), congress=118, treaty_number=2)
     assert isinstance(out, str)
-    assert "DATA_NOT_FOUND" in out and "SERVER_ERROR" not in out
+    assert "data_not_found" in out and "server_error" not in out
 
 
 @pytest.mark.asyncio
@@ -283,8 +283,8 @@ async def test_treaty_empty_list_is_not_found_not_server_error():
                       AsyncMock(return_value={"treaty": []})):
         out = await mod.get_treaty_text(FakeContext(), congress=118, treaty_number=99999)
     assert isinstance(out, str)
-    assert "DATA_NOT_FOUND" in out
-    assert "SERVER_ERROR" not in out and "has no attribute" not in out
+    assert "data_not_found" in out
+    assert "server_error" not in out and "has no attribute" not in out
 
 
 def test_treaty_record_accepts_dict_and_list():

--- a/tests/test_section9_envelope.py
+++ b/tests/test_section9_envelope.py
@@ -174,3 +174,10 @@ def test_wrapper_raises_typed_error_with_envelope_str():
     exc = CongressionalAPIError(err)
     payload = json.loads(str(exc))["error"]
     assert payload["code"] == "data_not_found"
+
+
+def test_embedded_url_in_detail_is_stripped():
+    from congress_api.core.exceptions import _strip_url_secrets
+    v = _strip_url_secrets("Failed to fetch https://cdn.example.com/f.xml?X-Amz-Signature=tok after retry")
+    assert "X-Amz-Signature" not in v
+    assert "https://cdn.example.com/f.xml" in v and "after retry" in v

--- a/tests/test_section9_envelope.py
+++ b/tests/test_section9_envelope.py
@@ -1,0 +1,176 @@
+"""One error envelope for the whole server (spec section 9).
+
+format_error_response emits {"error": {code, message, detail, remediation}}
+as JSON; structured tools additionally carry the typed `error` field with
+success=False. Codes are stable lowercase strings; detail never carries
+secret-bearing URLs (F22 rule).
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from congress_api.core.exceptions import (
+    CommonErrors,
+    CongressionalAPIError,
+    ErrorText,
+    error_envelope,
+    format_error_response,
+)
+
+
+class FakeContext:
+    async def info(self, *_):
+        pass
+
+    async def error(self, *_):
+        pass
+
+
+def _api_error(status):
+    return {"error": f"API request failed: {status}", "status_code": status,
+            "request_time": 0.1}
+
+
+# ---------------------------------------------------------------------------
+# the choke point
+# ---------------------------------------------------------------------------
+
+def test_format_error_response_is_json_envelope():
+    err = CommonErrors.data_not_found("bill", identifier="119/hr/9999999")
+    out = format_error_response(err)
+    assert isinstance(out, str) and isinstance(out, ErrorText)
+    payload = json.loads(out)["error"]
+    assert payload["code"] == "data_not_found"
+    assert "119/hr/9999999" in payload["message"]
+    assert payload["remediation"]            # suggestions folded in
+    assert out.error_response is err         # typed carrier for converters
+
+
+def test_envelope_strips_url_secrets_from_detail():
+    err = CommonErrors.api_server_error(
+        "/bill/119", message="boom")
+    err.details = {"endpoint": "/bill/119",
+                   "url": "https://api.congress.gov/v3/bill/119?api_key=SECRET123&format=json",
+                   "next": "https://cdn.example.com/file.xml?X-Amz-Signature=tok"}
+    payload = error_envelope(err)["error"]
+    assert payload["detail"]["url"] == "https://api.congress.gov/v3/bill/119"
+    assert "SECRET123" not in json.dumps(payload)
+    assert "X-Amz-Signature" not in json.dumps(payload)
+    assert payload["detail"]["endpoint"] == "/bill/119"   # non-URLs untouched
+
+
+def test_envelope_code_is_lowercase_stable():
+    for make, expected in (
+        (lambda: CommonErrors.invalid_parameter("x", 1, "bad"), "invalid_parameter"),
+        (lambda: CommonErrors.api_server_error("/x"), "server_error"),
+        (lambda: CommonErrors.rate_limit_exceeded("/x"), "rate_limit_exceeded"),
+    ):
+        assert error_envelope(make())["error"]["code"] == expected
+
+
+# ---------------------------------------------------------------------------
+# str-returning tools emit the envelope as their whole response
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_str_tool_404_is_parseable_envelope():
+    from congress_api.features.buckets.bills import api as mod
+    from congress_api.core import api_wrapper
+    with patch.object(api_wrapper, "make_api_request", AsyncMock(return_value=_api_error(404))):
+        out = await mod.get_bill_details(FakeContext(), congress=119, bill_type="hr",
+                                         bill_number=9999999)
+    payload = json.loads(out)["error"]
+    assert payload["code"] == "data_not_found"
+    assert "retrying will not help" in payload["remediation"]
+
+
+@pytest.mark.asyncio
+async def test_str_router_returns_envelope_not_toolerror():
+    """laws.* handlers call the wrapper bare; the router returns the JSON
+    envelope now instead of a stringified ToolError."""
+    from congress_api.features.buckets import laws as router
+    from congress_api.core import api_wrapper
+    with patch.object(api_wrapper, "make_api_request", AsyncMock(return_value=_api_error(404))):
+        out = await router.laws(FakeContext(), operation="get_law_details",
+                                congress=119, law_type="pub", law_number=999999)
+    payload = json.loads(out)["error"]
+    assert payload["code"] == "data_not_found"
+
+
+# ---------------------------------------------------------------------------
+# structured tools carry the typed error field
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_structured_tool_carries_error_field():
+    from congress_api.features import members_committees_tools as mod
+    from congress_api.core import api_wrapper
+    with patch.object(api_wrapper, "make_api_request", AsyncMock(return_value=_api_error(404))):
+        resp = await mod.get_member_details(FakeContext(), bioguide_id="ZZZ999")
+    assert resp.success is False
+    assert resp.error is not None
+    assert resp.error.code == "data_not_found"
+    assert resp.error.remediation
+    assert resp.results_count == 0
+    assert resp.summary.startswith("data_not_found:")
+
+
+@pytest.mark.asyncio
+async def test_model_router_carries_error_field():
+    from congress_api.features.buckets import voting_and_nominations as router
+    from congress_api.core import api_wrapper
+    with patch.object(api_wrapper, "make_api_request", AsyncMock(return_value=_api_error(404))):
+        resp = await router.voting_and_nominations(
+            FakeContext(), operation="get_nomination_details", congress=119,
+            nomination_number=999999)
+    assert resp.success is False and resp.error.code == "data_not_found"
+    assert resp.votes == [] and resp.nominations == []
+
+
+def test_all_five_converters_populate_error():
+    from congress_api.utils.response_converters import convert_members_committees_response
+    from congress_api.features.buckets.voting_and_nominations import (
+        _convert_to_structured_response as conv_votes)
+    from congress_api.features.buckets.records_and_hearings import (
+        _convert_to_structured_response as conv_records)
+    from congress_api.features.buckets.committee_intelligence import (
+        _convert_to_structured_response as conv_ci)
+    from congress_api.features.buckets.research_and_professional import (
+        _convert_to_structured_response as conv_research)
+    err_text = format_error_response(CommonErrors.data_not_found("thing", identifier="x"))
+    for conv in (lambda r: convert_members_committees_response(r, "op"),
+                 lambda r: conv_votes(r, "op"), lambda r: conv_records(r, "op"),
+                 lambda r: conv_ci(r, "op"), lambda r: conv_research(r, "op")):
+        resp = conv(err_text)
+        assert resp.success is False, conv
+        assert resp.error is not None and resp.error.code == "data_not_found"
+        assert resp.results_count == 0
+
+
+def test_success_paths_have_no_error_field():
+    from congress_api.utils.response_converters import convert_members_committees_response
+    resp = convert_members_committees_response("# X\nFound 2 members:", "op")
+    assert resp.success is True and resp.error is None
+
+
+@pytest.mark.asyncio
+async def test_wrapper_unexpected_exception_carries_internal_error():
+    from congress_api.features import members_committees_tools as mod
+    with patch("congress_api.features.members.get_member_details",
+               new=AsyncMock(side_effect=RuntimeError("boom"))):
+        resp = await mod.get_member_details(FakeContext(), bioguide_id="S000148")
+    assert resp.success is False
+    assert resp.error is not None and resp.error.code == "internal_error"
+    assert "boom" in resp.error.message
+
+
+def test_wrapper_raises_typed_error_with_envelope_str():
+    err = CommonErrors.data_not_found("bill", identifier="x")
+    exc = CongressionalAPIError(err)
+    payload = json.loads(str(exc))["error"]
+    assert payload["code"] == "data_not_found"

--- a/tests/test_typed_api_errors.py
+++ b/tests/test_typed_api_errors.py
@@ -92,8 +92,8 @@ async def test_get_member_details_reports_not_found():
     with patch.object(api_wrapper, "make_api_request", AsyncMock(return_value=_api_error(404))):
         out = await mod.get_member_details(FakeContext(), bioguide_id="ZZZ999")
     assert isinstance(out, str)
-    assert "DATA_NOT_FOUND" in out
-    assert "experiencing issues" not in out and "SERVER_ERROR" not in out
+    assert "data_not_found" in out
+    assert "experiencing issues" not in out and "server_error" not in out
 
 
 @pytest.mark.asyncio
@@ -104,7 +104,7 @@ async def test_get_bill_details_reports_not_found():
         out = await mod.get_bill_details(FakeContext(), congress=119, bill_type="hr",
                                          bill_number=9999999)
     assert isinstance(out, str)
-    assert "DATA_NOT_FOUND" in out
+    assert "data_not_found" in out
     assert "experiencing issues" not in out
 
 
@@ -115,7 +115,7 @@ async def test_get_treaty_detail_reports_not_found():
     with patch.object(api_wrapper, "make_api_request", AsyncMock(return_value=_api_error(404))):
         out = await mod.get_treaty_detail(FakeContext(), congress=118, treaty_number=99999)
     assert isinstance(out, str)
-    assert "DATA_NOT_FOUND" in out and "SERVER_ERROR" not in out
+    assert "data_not_found" in out and "server_error" not in out
 
 
 # ---------------------------------------------------------------------------
@@ -164,7 +164,7 @@ async def test_search_members_filtered_path_reports_not_found():
     from congress_api.core import api_wrapper
     with patch.object(api_wrapper, "make_api_request", AsyncMock(return_value=_api_error(404))):
         out = await mod.search_members(FakeContext(), state="WY", chamber="senate", congress=119)
-    assert "DATA_NOT_FOUND" in out and "SERVER_ERROR" not in out
+    assert "data_not_found" in out and "server_error" not in out
     assert "Pagination error" not in out
 
 
@@ -192,17 +192,15 @@ async def test_router_surfaces_typed_error_from_bare_handler():
     """nominations.* handlers call the wrapper with no try/except; the
     voting_and_nominations router must turn the typed error into a ToolError
     that carries the classification, not a generic failure."""
-    from mcp.server.mcpserver.exceptions import ToolError
     from congress_api.features.buckets import voting_and_nominations as router
     from congress_api.core import api_wrapper
     with patch.object(api_wrapper, "make_api_request", AsyncMock(return_value=_api_error(404))):
-        with pytest.raises(ToolError) as ei:
-            await router.voting_and_nominations(
-                FakeContext(), operation="get_nomination_details", congress=119,
-                nomination_number=999999)
-    msg = str(ei.value)
-    assert msg.startswith("DATA_NOT_FOUND:") or "DATA_NOT_FOUND:" in msg
-    assert "experiencing issues" not in msg and "❌" not in msg
+        resp = await router.voting_and_nominations(
+            FakeContext(), operation="get_nomination_details", congress=119,
+            nomination_number=999999)
+    assert resp.success is False
+    assert resp.error is not None and resp.error.code == "data_not_found"
+    assert "experiencing issues" not in resp.summary
 
 
 def test_every_router_has_typed_clause():


### PR DESCRIPTION
Implements the §9 error envelope (`documentation/fulltext/04-tools-responses.md`) across all 24 tools — the unification jds2001 proposed on #63: two error shapes (ToolError strings, markdown prose) become one machine-readable envelope, because a model parses structure, not paragraphs.

## Shape
- **str tools** (bills, amendments, laws, treaties): errors are now the JSON envelope itself — `{"error": {"code": "data_not_found", "message": …, "detail": …, "remediation": …}}`.
- **Structured tools** (17): `BaseResponse` gains `error: Optional[ErrorInfo]`; failures carry `success: false` + the typed envelope + a one-line summary.
- **Codes** are the #53 classification, lowercased (`data_not_found`, `invalid_parameter`, `rate_limit_exceeded`, `server_error`, `internal_error`) — carries over 1:1 as predicted.
- **Secret safety** (F22 rule generalized): any URL reaching `detail` is stripped to scheme+host+path.

## Mechanism
`format_error_response` is the single choke point: it renders the envelope and returns `ErrorText` (a `str` carrying its typed `APIErrorResponse`), so the five converters rebuild the typed field with zero re-parsing and ~500 call sites needed no changes. Routers return envelopes instead of stringified `ToolError`s.

## Honest side effect
`test_invoke_all_operations_with_defaults` failed on 29 operations after the change — those ops were *always* failing with schema defaults (e.g. `search_crs_reports` with no keywords), but hid it behind `success=True` markdown. The test's contract is now "no `internal_error`": honest domain errors allowed, crashes caught.

## Verification
- `tests/test_section9_envelope.py` (11 tests: choke point, secret-stripping, str/model routers, all five converters, internal_error on crashes) + 307 related tests green; gate + schema audit clean; lint at master parity.
- Live over stdio: bad bill → parseable `data_not_found` envelope with remediation; bad member → `success: false` + typed error; law/nomination 404s via routers → envelopes, not ToolErrors; good calls byte-identical behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)