### PR TITLE
Fix test_bucket_double_conversion.py on Python 3.10 (#45)

### DIFF
--- a/tests/test_bucket_double_conversion.py
+++ b/tests/test_bucket_double_conversion.py
@@ -27,7 +27,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 
 class FakeContext:
@@ -46,8 +46,14 @@ async def test_committee_intelligence_does_not_double_convert():
     from congress_api.features.buckets import committee_intelligence as mod
 
     raw = _fabricated_markdown(5, "# Committee Reports (5 found)")
+    # autospec=True is load-bearing, not stylistic (issue #45): a bare
+    # AsyncMock(return_value=...) has no real signature, and
+    # inspect.signature() on it crashes on Python 3.10 (the project's
+    # declared floor) inside operation_routing.validate_operation_kwargs,
+    # even though it works fine on 3.11+. Don't "simplify" this back.
     with patch("congress_api.features.committee_reports.get_latest_committee_reports",
-               new=AsyncMock(return_value=raw)):
+               autospec=True) as mock_handler:
+        mock_handler.return_value = raw
         resp = await mod.committee_intelligence(FakeContext(), operation="get_latest_committee_reports")
 
     assert resp.results_count == 5, "double-conversion bug: results_count always 0"
@@ -60,7 +66,9 @@ async def test_records_and_hearings_does_not_double_convert():
     from congress_api.features.buckets import records_and_hearings as mod
 
     raw = _fabricated_markdown(5, "Found 5 hearings")
-    with patch("congress_api.features.hearings.search_hearings", new=AsyncMock(return_value=raw)):
+    # autospec=True required on Python 3.10 -- see comment in the test above.
+    with patch("congress_api.features.hearings.search_hearings", autospec=True) as mock_handler:
+        mock_handler.return_value = raw
         resp = await mod.records_and_hearings(FakeContext(), operation="search_hearings", congress=119)
 
     assert resp.results_count == 5
@@ -73,7 +81,9 @@ async def test_research_and_professional_does_not_double_convert():
     from congress_api.features.buckets import research_and_professional as mod
 
     raw = _fabricated_markdown(5, "Found 5 reports")
-    with patch("congress_api.features.crs_reports.search_crs_reports", new=AsyncMock(return_value=raw)):
+    # autospec=True required on Python 3.10 -- see comment in the test above.
+    with patch("congress_api.features.crs_reports.search_crs_reports", autospec=True) as mock_handler:
+        mock_handler.return_value = raw
         resp = await mod.research_and_professional(FakeContext(), operation="search_crs_reports", keywords="x")
 
     assert resp.results_count == 5
@@ -86,7 +96,9 @@ async def test_voting_and_nominations_does_not_double_convert():
     from congress_api.features.buckets import voting_and_nominations as mod
 
     raw = _fabricated_markdown(5, "# Latest Nominations (5 found)")
-    with patch("congress_api.features.nominations.get_latest_nominations", new=AsyncMock(return_value=raw)):
+    # autospec=True required on Python 3.10 -- see comment in the test above.
+    with patch("congress_api.features.nominations.get_latest_nominations", autospec=True) as mock_handler:
+        mock_handler.return_value = raw
         resp = await mod.voting_and_nominations(FakeContext(), operation="get_latest_nominations")
 
     assert resp.results_count == 5


### PR DESCRIPTION
## Summary
- Four tests in `tests/test_bucket_double_conversion.py` patched handler functions with bare `unittest.mock.AsyncMock(return_value=...)`. On Python 3.10 (the project's declared floor, `requires-python = ">=3.10"`), `inspect.signature()` cannot properly introspect a spec-less mock and raises `TypeError: 'Mock' object is not subscriptable` from inside `operation_routing.validate_operation_kwargs`, which every bucket router calls before dispatching to a handler. Python 3.11+ doesn't hit the same code path, which is why CI (3.12) stayed green while local 3.10 runs failed.
- Switched all four patches to `patch(..., autospec=True)`, the fix the issue itself named as preferred over bumping the Python floor or adding a 3.10 CI leg. Autospec builds each mock's signature from the real handler, so `inspect.signature()` resolves correctly on every supported Python version, and the mock still validates call arguments against the real handler's signature.
- Added a comment on each patch marking `autospec=True` as load-bearing (not stylistic), since a future "simplification" back to a bare `AsyncMock` is exactly the regression this issue describes.

## Assumptions Made
- None — followed the issue's explicitly preferred fix option (autospec/create_autospec against the real handler) rather than bumping `requires-python`/`.python-version` or adding a 3.10 CI matrix leg.

## Quality gates
- [x] All tests passing (736 passed, 5 skipped on Python 3.10; 11/11 in the target file, up from 4 failed/7 passed)
- [x] Lint clean (no new violations; one pre-existing E501 in the target file, unrelated to this diff)
- [x] Code critique: PASS (score 92/100, reviewer confirmed via mutation testing that the tests still catch the original double-conversion bug)
- [x] No regressions (`tests/check_known_failures.py` reports a clean baseline: "2 known failures, 4 known collection errors, nothing new"; 2 pre-existing unrelated failures in `test_registration_endpoint.py` reproduce identically on `master`)

## Known Limitations
- None

Closes #45