### PR TITLE
Honor Retry-After and per-endpoint timeouts in the API wrapper

### DIFF
--- a/congress_api/core/api_wrapper.py
+++ b/congress_api/core/api_wrapper.py
@@ -10,6 +10,8 @@ from .client_handler import make_api_request
 from .exceptions import APIErrorResponse, CongressionalAPIError
 from .retry_timing import parse_retry_after
 
+logger = logging.getLogger(__name__)
+
 @dataclass
 class APIEndpointConfig:
     timeout: float = 10.0; retry_count: int = 1; retry_delay: float = 1.0; max_retry_delay: float = 5.0
@@ -45,13 +47,17 @@ def _retry_after_seconds(error: Exception, status: Optional[int]) -> Optional[fl
 def _next_delay(retry_after: Optional[float], fallback_delay: float, cap: float) -> float:
     """Seconds to sleep before the next retry.
 
-    Uses `retry_after` (already resolved by `_retry_after_seconds`, already
-    known to be <= cap -- see the give-up branch in safe_api_request) when
-    given; otherwise falls back to exponential backoff with jitter, capped at
-    the endpoint's max_retry_delay.
+    Uses `retry_after` (already resolved by `_retry_after_seconds`) when
+    given, capped at the endpoint's max_retry_delay so a server asking for an
+    hour-scale wait can't stall a tool call for anywhere near that long;
+    otherwise falls back to exponential backoff with jitter, capped the same
+    way. Per spec (documentation/fulltext/03-data-sources.md's rate-limits
+    section): "respect Retry-After on both 429 and 503, capped at a maximum
+    wait" -- capped-and-retried, not abandoned, even when the header asks for
+    more than the cap.
     """
     if retry_after is not None:
-        return retry_after
+        return min(retry_after, cap)
     return min(fallback_delay + random.uniform(0, 0.25), cap)
 
 
@@ -123,11 +129,10 @@ class DefensiveAPIWrapper:
                 # Congress.gov exactly when the key was already being throttled.
                 retry_after = _retry_after_seconds(e, status)
                 if retry_after is not None and retry_after > config.max_retry_delay:
-                    # The server wants longer than we're willing to block a
-                    # tool call for. Sleeping the capped value anyway would
-                    # just spend the remaining attempts hitting the same
-                    # still-throttled key again, so give up now instead.
-                    break
+                    logger.warning(
+                        "Congress.gov asked for a %.0fs wait on %s (429/503); "
+                        "capping the retry sleep at %.0fs per endpoint config.",
+                        retry_after, endpoint, config.max_retry_delay)
                 await asyncio.sleep(_next_delay(retry_after, retry_delay, config.max_retry_delay))
                 retry_delay = min(retry_delay * config.backoff_multiplier, config.max_retry_delay)
         

--- a/congress_api/core/api_wrapper.py
+++ b/congress_api/core/api_wrapper.py
@@ -2,6 +2,9 @@
 
 import asyncio
 import logging
+import random
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Dict, Any, Optional
 from dataclasses import dataclass, replace
 from mcp.server.mcpserver import Context
@@ -14,10 +17,50 @@ class APIEndpointConfig:
     backoff_multiplier: float = 2.0; sanitize_params: bool = True; remove_empty_params: bool = True
 
 class _HTTPStatusFailure(Exception):
-    """Internal: carries the HTTP status from make_api_request's error dict."""
-    def __init__(self, status_code, message):
+    """Internal: carries the HTTP status (and, for 429/503, the Retry-After /
+    X-RateLimit-Remaining headers) from make_api_request's error dict."""
+    def __init__(self, status_code, message, retry_after=None, rate_limit_remaining=None):
         self.status_code = status_code
+        self.retry_after = retry_after
+        self.rate_limit_remaining = rate_limit_remaining
         super().__init__(f"API Error ({status_code}): {message}")
+
+
+# Statuses where the server may tell us exactly how long to wait, same set
+# the GovInfo client (features/bill_text/client.py) already backs off on.
+_RETRY_AFTER_STATUSES = frozenset({429, 503})
+
+
+def _parse_retry_after(value: Optional[str]) -> Optional[float]:
+    """Seconds to wait from a Retry-After header value, or None if unusable.
+
+    Retry-After is either a delay in seconds or an HTTP-date (RFC 7231 §7.1.3);
+    mirrors bill_text/client.py's `_retry_after`.
+    """
+    if not value:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        try:
+            return max(0.0, (parsedate_to_datetime(value) - datetime.now(timezone.utc)).total_seconds())
+        except (TypeError, ValueError):
+            return None
+
+
+def _next_delay(error: Exception, status: Optional[int], fallback_delay: float, cap: float) -> float:
+    """Seconds to sleep before the next retry.
+
+    Honors Retry-After on 429/503 when the server sent one; otherwise falls
+    back to exponential backoff with jitter. Either way the result is capped
+    at the endpoint's max_retry_delay so a large/malformed Retry-After can't
+    stall a tool call.
+    """
+    if status in _RETRY_AFTER_STATUSES:
+        retry_after = _parse_retry_after(getattr(error, "retry_after", None))
+        if retry_after is not None:
+            return min(retry_after, cap)
+    return min(fallback_delay + random.uniform(0, 0.25), cap)
 
 
 class DefensiveAPIWrapper:
@@ -66,17 +109,15 @@ class DefensiveAPIWrapper:
         
         sanitized_params = DefensiveAPIWrapper._sanitize_parameters(params, config)
         last_error = None; retry_delay = config.retry_delay
-        
+
         for attempt in range(config.retry_count + 1):
             try:
-                if attempt > 0:
-                    await asyncio.sleep(retry_delay)
-                    retry_delay = min(retry_delay * config.backoff_multiplier, config.max_retry_delay)
-                
-                response = await make_api_request(endpoint, ctx, sanitized_params)
+                response = await make_api_request(endpoint, ctx, sanitized_params, timeout=config.timeout)
                 if isinstance(response, dict) and 'error' in response:
                     raise _HTTPStatusFailure(response.get('status_code'),
-                                             response.get('error', 'Unknown API error'))
+                                             response.get('error', 'Unknown API error'),
+                                             retry_after=response.get('retry_after'),
+                                             rate_limit_remaining=response.get('rate_limit_remaining'))
                 return response
             except Exception as e:
                 last_error = e
@@ -84,6 +125,12 @@ class DefensiveAPIWrapper:
                 status = getattr(e, "status_code", None)
                 if status in (400, 404): break
                 if status is None and any(x in str(e).lower() for x in ["404", "not found", "400", "bad request"]): break
+                if attempt >= config.retry_count: break
+                # 429/503: honor Retry-After instead of retrying immediately
+                # (issue #58) -- that's what was multiplying requests against
+                # Congress.gov exactly when the key was already being throttled.
+                await asyncio.sleep(_next_delay(e, status, retry_delay, config.max_retry_delay))
+                retry_delay = min(retry_delay * config.backoff_multiplier, config.max_retry_delay)
         
         error_response = DefensiveAPIWrapper._format_api_error(endpoint, last_error, config.retry_count)
         # Raise the *typed* error so handlers can report not-found / bad-request
@@ -117,7 +164,15 @@ class DefensiveAPIWrapper:
             return APIErrorResponse("validation", f"Congress.gov rejected the request to {endpoint} (400).",
                                     ["Check parameter names, formats and ranges"], "INVALID_PARAMETERS")
         if status == 429:
-            return APIErrorResponse("rate_limit", f"Congress.gov rate limit hit on {endpoint} (429).",
+            message = f"Congress.gov rate limit hit on {endpoint} (429)."
+            remaining = getattr(error, "rate_limit_remaining", None)
+            if remaining is not None:
+                try:
+                    if int(remaining) <= 0:
+                        message += f" X-RateLimit-Remaining: {remaining}."
+                except (TypeError, ValueError):
+                    pass
+            return APIErrorResponse("rate_limit", message,
                                     ["Wait a minute and retry", "Reduce request volume"], "RATE_LIMIT_EXCEEDED")
         if isinstance(status, int) and status >= 500:
             return APIErrorResponse("server_error", f"Congress.gov returned {status} for {endpoint}.",

--- a/congress_api/core/api_wrapper.py
+++ b/congress_api/core/api_wrapper.py
@@ -3,13 +3,12 @@
 import asyncio
 import logging
 import random
-from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
 from typing import Dict, Any, Optional
 from dataclasses import dataclass, replace
 from mcp.server.mcpserver import Context
 from .client_handler import make_api_request
 from .exceptions import APIErrorResponse, CongressionalAPIError
+from .retry_timing import parse_retry_after
 
 @dataclass
 class APIEndpointConfig:
@@ -31,35 +30,28 @@ class _HTTPStatusFailure(Exception):
 _RETRY_AFTER_STATUSES = frozenset({429, 503})
 
 
-def _parse_retry_after(value: Optional[str]) -> Optional[float]:
-    """Seconds to wait from a Retry-After header value, or None if unusable.
+def _retry_after_seconds(error: Exception, status: Optional[int]) -> Optional[float]:
+    """The usable Retry-After delay for this failure, or None.
 
-    Retry-After is either a delay in seconds or an HTTP-date (RFC 7231 §7.1.3);
-    mirrors bill_text/client.py's `_retry_after`.
+    None means either the status doesn't carry Retry-After semantics, or the
+    header was absent/unusable -- parse_retry_after already rejects negative,
+    zero, and non-finite values, so a caller never has to re-check those.
     """
-    if not value:
+    if status not in _RETRY_AFTER_STATUSES:
         return None
-    try:
-        return float(value)
-    except ValueError:
-        try:
-            return max(0.0, (parsedate_to_datetime(value) - datetime.now(timezone.utc)).total_seconds())
-        except (TypeError, ValueError):
-            return None
+    return parse_retry_after(getattr(error, "retry_after", None))
 
 
-def _next_delay(error: Exception, status: Optional[int], fallback_delay: float, cap: float) -> float:
+def _next_delay(retry_after: Optional[float], fallback_delay: float, cap: float) -> float:
     """Seconds to sleep before the next retry.
 
-    Honors Retry-After on 429/503 when the server sent one; otherwise falls
-    back to exponential backoff with jitter. Either way the result is capped
-    at the endpoint's max_retry_delay so a large/malformed Retry-After can't
-    stall a tool call.
+    Uses `retry_after` (already resolved by `_retry_after_seconds`, already
+    known to be <= cap -- see the give-up branch in safe_api_request) when
+    given; otherwise falls back to exponential backoff with jitter, capped at
+    the endpoint's max_retry_delay.
     """
-    if status in _RETRY_AFTER_STATUSES:
-        retry_after = _parse_retry_after(getattr(error, "retry_after", None))
-        if retry_after is not None:
-            return min(retry_after, cap)
+    if retry_after is not None:
+        return retry_after
     return min(fallback_delay + random.uniform(0, 0.25), cap)
 
 
@@ -129,7 +121,14 @@ class DefensiveAPIWrapper:
                 # 429/503: honor Retry-After instead of retrying immediately
                 # (issue #58) -- that's what was multiplying requests against
                 # Congress.gov exactly when the key was already being throttled.
-                await asyncio.sleep(_next_delay(e, status, retry_delay, config.max_retry_delay))
+                retry_after = _retry_after_seconds(e, status)
+                if retry_after is not None and retry_after > config.max_retry_delay:
+                    # The server wants longer than we're willing to block a
+                    # tool call for. Sleeping the capped value anyway would
+                    # just spend the remaining attempts hitting the same
+                    # still-throttled key again, so give up now instead.
+                    break
+                await asyncio.sleep(_next_delay(retry_after, retry_delay, config.max_retry_delay))
                 retry_delay = min(retry_delay * config.backoff_multiplier, config.max_retry_delay)
         
         error_response = DefensiveAPIWrapper._format_api_error(endpoint, last_error, config.retry_count)
@@ -168,10 +167,11 @@ class DefensiveAPIWrapper:
             remaining = getattr(error, "rate_limit_remaining", None)
             if remaining is not None:
                 try:
-                    if int(remaining) <= 0:
-                        message += f" X-RateLimit-Remaining: {remaining}."
+                    remaining_int = int(remaining)
                 except (TypeError, ValueError):
-                    pass
+                    remaining_int = None
+                if remaining_int is not None and remaining_int <= 0:
+                    message += f" X-RateLimit-Remaining: {remaining_int}."
             return APIErrorResponse("rate_limit", message,
                                     ["Wait a minute and retry", "Reduce request volume"], "RATE_LIMIT_EXCEEDED")
         if isinstance(status, int) and status >= 500:

--- a/congress_api/core/client_handler.py
+++ b/congress_api/core/client_handler.py
@@ -129,12 +129,19 @@ def generate_cache_key(endpoint: str, params: Dict[str, Any]) -> str:
     return f"{endpoint}?{param_str}"
 
 # Helper function for API requests
-async def make_api_request(endpoint: str, ctx: Optional[Context] = None, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+async def make_api_request(endpoint: str, ctx: Optional[Context] = None, params: Optional[Dict[str, Any]] = None,
+                            timeout: Optional[float] = None) -> Dict[str, Any]:
     """Make a request to the Congress.gov API with caching and proper error handling.
 
     `ctx` is the request's MCP Context, used by tools and templated resources.
     Static resource handlers can't declare a Context parameter under MCP SDK v2,
     so they pass `ctx=None` and the AppContext is pulled from `get_app_context()` instead.
+
+    `timeout` overrides the client's default httpx timeout for this request only
+    (issue #58: per-endpoint timeouts from DefensiveAPIWrapper were computed but
+    never reached httpx). Omitted/None keeps the client's own default -- passing
+    `timeout=None` straight to httpx would instead disable the timeout entirely,
+    so it is only forwarded when the caller supplied a value.
     """
     start_time = time.time()
 
@@ -179,8 +186,11 @@ async def make_api_request(endpoint: str, ctx: Optional[Context] = None, params:
         logger.debug(f"Making request to {endpoint}")
         if ENV != "production":  # Only log params in non-production
             logger.debug(f"Request parameters: {safe_params}")
-            
-        response = await client.get(endpoint, params=request_params)
+
+        request_kwargs = {"params": request_params}
+        if timeout is not None:
+            request_kwargs["timeout"] = timeout
+        response = await client.get(endpoint, **request_kwargs)
         response.raise_for_status()
         
         # Parse the response
@@ -222,12 +232,34 @@ async def make_api_request(endpoint: str, ctx: Optional[Context] = None, params:
         if ctx is not None:
             ctx.error(ctx_error_message)
 
-        # Return an error response with enough detail for clients
-        # We'll keep the original error message but sanitize it for logging
+        # Return an error response with enough detail for clients. Retry-After
+        # and X-RateLimit-Remaining (issue #58) let DefensiveAPIWrapper pace
+        # 429 retries off the server's own guidance instead of blind backoff.
         return {
-            "error": f"API request failed: {e.response.status_code}", 
+            "error": f"API request failed: {e.response.status_code}",
             "status_code": e.response.status_code,
-            "request_time": request_time
+            "request_time": request_time,
+            "retry_after": e.response.headers.get("Retry-After"),
+            "rate_limit_remaining": e.response.headers.get("X-RateLimit-Remaining"),
+        }
+    except httpx.TimeoutException as e:
+        request_time = time.time() - start_time
+
+        log_error_message = f"API request to {endpoint} exceeded its timeout"
+        logger.error(log_error_message)
+
+        # Must contain "timeout" -- DefensiveAPIWrapper._classify_api_error
+        # matches on it to report API_TIMEOUT instead of a generic failure.
+        ctx_error_message = f"API request timeout after {request_time:.2f}s"
+        if ENV != "production":
+            ctx_error_message += f": {str(e)}"
+
+        if ctx is not None:
+            ctx.error(ctx_error_message)
+
+        return {
+            "error": f"API request timeout for endpoint {endpoint} after {request_time:.2f}s",
+            "request_time": request_time,
         }
     except httpx.RequestError as e:
         request_time = time.time() - start_time

--- a/congress_api/core/client_handler.py
+++ b/congress_api/core/client_handler.py
@@ -189,7 +189,10 @@ async def make_api_request(endpoint: str, ctx: Optional[Context] = None, params:
 
         request_kwargs = {"params": request_params}
         if timeout is not None:
-            request_kwargs["timeout"] = timeout
+            # A bare float would override connect/write/pool too, loosening
+            # the 5s connect timeout the client was built with (line ~90).
+            # Only the read timeout is meant to vary per endpoint.
+            request_kwargs["timeout"] = httpx.Timeout(timeout, connect=5.0)
         response = await client.get(endpoint, **request_kwargs)
         response.raise_for_status()
         
@@ -257,8 +260,13 @@ async def make_api_request(endpoint: str, ctx: Optional[Context] = None, params:
         if ctx is not None:
             ctx.error(ctx_error_message)
 
+        # No endpoint/digits in the returned message (endpoint is only in the
+        # log line above): DefensiveAPIWrapper's no-status-code fallback does
+        # a substring scan for "400"/"404" on str(error), and an endpoint
+        # like /bill/118/hr/404 would false-positive that scan and skip
+        # retries on a plain timeout.
         return {
-            "error": f"API request timeout for endpoint {endpoint} after {request_time:.2f}s",
+            "error": f"API request timeout after {request_time:.2f}s",
             "request_time": request_time,
         }
     except httpx.RequestError as e:

--- a/congress_api/core/client_handler.py
+++ b/congress_api/core/client_handler.py
@@ -189,10 +189,12 @@ async def make_api_request(endpoint: str, ctx: Optional[Context] = None, params:
 
         request_kwargs = {"params": request_params}
         if timeout is not None:
-            # A bare float would override connect/write/pool too, loosening
-            # the 5s connect timeout the client was built with (line ~90).
-            # Only the read timeout is meant to vary per endpoint.
-            request_kwargs["timeout"] = httpx.Timeout(timeout, connect=5.0)
+            # A bare float would set connect/write/pool to it too, loosening
+            # the 5s connect timeout the client was built with (line ~90) and
+            # tying write/pool to a value meant to vary per-endpoint for
+            # reads. Only the read timeout is meant to vary; connect/write/
+            # pool stay at the client's own defaults (10.0/10.0, line ~90).
+            request_kwargs["timeout"] = httpx.Timeout(connect=5.0, read=timeout, write=10.0, pool=10.0)
         response = await client.get(endpoint, **request_kwargs)
         response.raise_for_status()
         

--- a/congress_api/core/retry_timing.py
+++ b/congress_api/core/retry_timing.py
@@ -1,0 +1,40 @@
+"""Shared Retry-After parsing for the Congress.gov and GovInfo clients.
+
+Extracted from congress_api/features/bill_text/client.py's original
+`_retry_after` (issue #58 code review): that helper had no clamp on the
+numeric branch, so a negative, zero, or non-finite ``Retry-After`` value
+(`"-30"`, `"nan"`, a past HTTP-date after clock skew) sailed straight into
+``asyncio.sleep()`` -- a negative/zero value fires the retry immediately
+(worse than no Retry-After handling at all against a throttled key), and
+``asyncio.sleep(float('nan'))`` never returns. Both congress_api/core/api_wrapper.py
+and bill_text/client.py backed off using a copy of the same unclamped logic;
+this is the one fixed implementation both call.
+"""
+
+import math
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Optional
+
+
+def parse_retry_after(value: Optional[str]) -> Optional[float]:
+    """Seconds to wait from a Retry-After header value, or None if unusable.
+
+    Retry-After is either a delay in seconds or an HTTP-date (RFC 7231
+    §7.1.3). A parsed value that isn't a positive, finite number of seconds
+    (negative, zero, NaN, infinite, or a past HTTP-date) is treated the same
+    as a missing header -- None -- so callers fall back to their own
+    backoff instead of sleeping for zero seconds or hanging forever.
+    """
+    if not value:
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        try:
+            seconds = (parsedate_to_datetime(value) - datetime.now(timezone.utc)).total_seconds()
+        except (TypeError, ValueError):
+            return None
+    if not math.isfinite(seconds) or seconds <= 0:
+        return None
+    return seconds

--- a/congress_api/core/retry_timing.py
+++ b/congress_api/core/retry_timing.py
@@ -30,7 +30,7 @@ def parse_retry_after(value: Optional[str]) -> Optional[float]:
         return None
     try:
         seconds = float(value)
-    except ValueError:
+    except (TypeError, ValueError):
         try:
             seconds = (parsedate_to_datetime(value) - datetime.now(timezone.utc)).total_seconds()
         except (TypeError, ValueError):

--- a/congress_api/features/bill_text/client.py
+++ b/congress_api/features/bill_text/client.py
@@ -11,7 +11,6 @@ import random
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
 from typing import Any, Callable
 
 import httpx
@@ -19,6 +18,7 @@ from mcp.server.mcpserver import Context
 
 from ...core.api_config import API_KEY
 from ...core.client_handler import make_api_request
+from ...core.retry_timing import parse_retry_after as _retry_after
 
 
 logger = logging.getLogger(__name__)
@@ -552,16 +552,11 @@ async def _follow_with_key(
     )
 
 
-def _retry_after(value: str | None) -> float | None:
-    if not value:
-        return None
-    try:
-        return float(value)
-    except ValueError:
-        try:
-            return max(0.0, (parsedate_to_datetime(value) - datetime.now(timezone.utc)).total_seconds())
-        except (TypeError, ValueError):
-            return None
+# _retry_after -- Retry-After header parsing -- now lives in
+# core/retry_timing.py (issue #58 code review: this copy had no clamp on
+# the numeric branch, so a negative/NaN Retry-After fed straight into
+# min(sleep_for, 8.0) below, and min() with NaN doesn't clamp). Imported
+# above as `_retry_after` so the call site here is unchanged.
 
 
 def _xml_url_from_summary(data: dict[str, Any]) -> str | None:

--- a/tests/test_retry_after.py
+++ b/tests/test_retry_after.py
@@ -57,24 +57,28 @@ async def test_429_sleeps_for_retry_after_seconds():
 
 
 @pytest.mark.asyncio
-async def test_429_retry_after_beyond_cap_gives_up_instead_of_retrying():
-    """A Retry-After longer than the endpoint's max_retry_delay means the key
-    is throttled well past what we're willing to block a tool call for.
-    Sleeping the capped value anyway would just spend the remaining retries
-    hitting the same still-throttled key again, so give up on the first
-    failure instead of retrying at all."""
+async def test_429_retry_after_beyond_cap_is_capped_not_abandoned():
+    """A Retry-After longer than the endpoint's max_retry_delay is still
+    honored, just capped -- per spec (documentation/fulltext/03-data-
+    sources.md's rate-limits section): "respect Retry-After on both 429 and
+    503, capped at a maximum wait." Capped-and-retried, not abandoned."""
     from congress_api.core import api_wrapper as mod
     from congress_api.core.exceptions import CongressionalAPIError
 
+    sleep_calls = []
+
+    async def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
     mock = AsyncMock(return_value=_rate_limited(retry_after="120"))
     with patch.object(mod, "make_api_request", mock), \
-            patch.object(mod.asyncio, "sleep", AsyncMock()) as sleep_mock:
+            patch.object(mod.asyncio, "sleep", fake_sleep):
         with pytest.raises(CongressionalAPIError) as ei:
             await mod.safe_congressional_request("/bill/119", FakeContext(), {},
                                                  endpoint_type="default")  # max_retry_delay=5.0
 
-    assert mock.await_count == 1
-    sleep_mock.assert_not_awaited()
+    assert mock.await_count == 2  # 1 initial + 1 retry (default retry_count=1)
+    assert sleep_calls == [5.0]  # capped, not the raw 120s
     assert ei.value.error_response.error_code == "RATE_LIMIT_EXCEEDED"
 
 
@@ -103,6 +107,16 @@ async def test_429_without_retry_after_falls_back_to_backoff_with_jitter():
     # Later steps grow (backoff_multiplier=2.0) up to the 5.0s cap.
     assert sleep_calls[-1] <= 5.0
     assert sleep_calls[0] <= sleep_calls[-1]
+
+
+def test_next_delay_backoff_clamp_actually_fires():
+    """A direct check that the exponential-backoff branch's min(..., cap) is
+    load-bearing -- 'bills' (retry_count=3) never grows past 4.25s so the
+    wrapper-level test above passes whether or not the clamp exists."""
+    from congress_api.core.api_wrapper import _next_delay
+
+    assert _next_delay(None, fallback_delay=10.0, cap=5.0) == 5.0
+    assert _next_delay(None, fallback_delay=1.0, cap=5.0) <= 5.0
 
 
 @pytest.mark.asyncio
@@ -240,11 +254,15 @@ async def test_make_api_request_forwards_timeout_kwarg_to_httpx():
                                     {"limit": 5}, timeout=8.0)
 
     # A bare float would also loosen the 5s connect timeout the client was
-    # built with; only the read/write/pool legs should track the override.
+    # built with and tie write/pool to a value meant to vary per-endpoint
+    # for reads; only the read leg should track the override.
     import httpx
     sent_timeout = fake_client.get.await_args.kwargs["timeout"]
-    assert sent_timeout == httpx.Timeout(8.0, connect=5.0)
+    assert sent_timeout == httpx.Timeout(connect=5.0, read=8.0, write=10.0, pool=10.0)
     assert sent_timeout.connect == 5.0
+    assert sent_timeout.read == 8.0
+    assert sent_timeout.write == 10.0
+    assert sent_timeout.pool == 10.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_retry_after.py
+++ b/tests/test_retry_after.py
@@ -1,0 +1,269 @@
+"""Issue #58: a 429 from Congress.gov must not be retried immediately and in
+quick succession -- it must honor Retry-After (falling back to exponential
+backoff with jitter, capped), surface X-RateLimit-Remaining when exhausted,
+and per-endpoint timeouts must actually reach httpx.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class FakeContext:
+    async def info(self, *_):
+        pass
+
+    async def error(self, *_):
+        pass
+
+
+def _rate_limited(retry_after=None, remaining=None):
+    return {
+        "error": "API request failed: 429",
+        "status_code": 429,
+        "request_time": 0.01,
+        "retry_after": retry_after,
+        "rate_limit_remaining": remaining,
+    }
+
+
+# ---------------------------------------------------------------------------
+# DefensiveAPIWrapper: Retry-After pacing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_429_sleeps_for_retry_after_seconds():
+    """A numeric Retry-After header paces the retry, not the blind backoff."""
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+
+    sleep_calls = []
+
+    async def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    with patch.object(mod, "make_api_request",
+                      AsyncMock(return_value=_rate_limited(retry_after="3"))), \
+            patch.object(mod.asyncio, "sleep", fake_sleep):
+        with pytest.raises(CongressionalAPIError):
+            await mod.safe_congressional_request("/bill/119", FakeContext(), {},
+                                                 endpoint_type="bills")  # retry_count=3
+
+    # Every retry used the server's Retry-After value (3s), not 1s/2s/4s backoff.
+    assert sleep_calls == [3, 3, 3]
+
+
+@pytest.mark.asyncio
+async def test_429_retry_after_is_capped_at_max_retry_delay():
+    """A large/malformed Retry-After can't stall a tool call past the
+    endpoint's configured cap."""
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+
+    sleep_calls = []
+
+    async def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    with patch.object(mod, "make_api_request",
+                      AsyncMock(return_value=_rate_limited(retry_after="120"))), \
+            patch.object(mod.asyncio, "sleep", fake_sleep):
+        with pytest.raises(CongressionalAPIError):
+            await mod.safe_congressional_request("/bill/119", FakeContext(), {},
+                                                 endpoint_type="default")  # max_retry_delay=5.0
+
+    assert sleep_calls and all(s <= 5.0 for s in sleep_calls)
+
+
+@pytest.mark.asyncio
+async def test_429_without_retry_after_falls_back_to_backoff_with_jitter():
+    """No Retry-After header: exponential backoff+jitter, still capped -- and
+    still far from 'retried immediately'."""
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+
+    sleep_calls = []
+
+    async def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    with patch.object(mod, "make_api_request",
+                      AsyncMock(return_value=_rate_limited())), \
+            patch.object(mod.asyncio, "sleep", fake_sleep):
+        with pytest.raises(CongressionalAPIError):
+            await mod.safe_congressional_request("/bill/119", FakeContext(), {},
+                                                 endpoint_type="bills")  # retry_count=3
+
+    assert len(sleep_calls) == 3
+    # First backoff step starts near retry_delay=1.0 (+ up to 0.25 jitter).
+    assert 1.0 <= sleep_calls[0] <= 1.25
+    # Later steps grow (backoff_multiplier=2.0) up to the 5.0s cap.
+    assert sleep_calls[-1] <= 5.0
+    assert sleep_calls[0] <= sleep_calls[-1]
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_remaining_surfaced_when_exhausted():
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+
+    with patch.object(mod, "make_api_request",
+                      AsyncMock(return_value=_rate_limited(retry_after="1", remaining="0"))), \
+            patch.object(mod.asyncio, "sleep", AsyncMock()):
+        with pytest.raises(CongressionalAPIError) as ei:
+            await mod.safe_congressional_request("/bill/119", FakeContext(), {},
+                                                 endpoint_type="default")
+
+    err = ei.value.error_response
+    assert err.error_code == "RATE_LIMIT_EXCEEDED"
+    assert "X-RateLimit-Remaining: 0" in err.message
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_remaining_omitted_when_nonzero():
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+
+    with patch.object(mod, "make_api_request",
+                      AsyncMock(return_value=_rate_limited(retry_after="1", remaining="42"))), \
+            patch.object(mod.asyncio, "sleep", AsyncMock()):
+        with pytest.raises(CongressionalAPIError) as ei:
+            await mod.safe_congressional_request("/bill/119", FakeContext(), {},
+                                                 endpoint_type="default")
+
+    assert "X-RateLimit-Remaining" not in ei.value.error_response.message
+
+
+@pytest.mark.asyncio
+async def test_wrapper_passes_endpoint_timeout_to_make_api_request():
+    """The per-endpoint config.timeout (issue #58) must actually reach
+    make_api_request, not just be computed and discarded."""
+    from congress_api.core import api_wrapper as mod
+
+    mock = AsyncMock(return_value={"result": "ok"})
+    with patch.object(mod, "make_api_request", mock):
+        await mod.safe_congressional_request("/bound-congressional-record/2020",
+                                             FakeContext(), {})  # timeout=15.0
+
+    assert mock.await_args.kwargs["timeout"] == 15.0
+
+
+# ---------------------------------------------------------------------------
+# client_handler: timeout actually reaches httpx, headers are captured
+# ---------------------------------------------------------------------------
+
+class _FakeAppContext:
+    def __init__(self, client):
+        self.client = client
+        self.api_key = "TESTKEY"
+        self.request_count = 0
+
+
+class _FakeRequestContext:
+    def __init__(self, app_ctx):
+        self.lifespan_context = app_ctx
+
+
+class _FakeCtx:
+    def __init__(self, app_ctx):
+        self.request_context = _FakeRequestContext(app_ctx)
+
+    def error(self, *_):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_make_api_request_forwards_timeout_kwarg_to_httpx():
+    from congress_api.core import client_handler as mod
+
+    response = MagicMock()
+    response.json.return_value = {"ok": True}
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=response)
+
+    with patch.object(mod, "ENABLE_CACHING", False):
+        await mod.make_api_request("/bill/119", _FakeCtx(_FakeAppContext(fake_client)),
+                                    {"limit": 5}, timeout=8.0)
+
+    assert fake_client.get.await_args.kwargs["timeout"] == 8.0
+
+
+@pytest.mark.asyncio
+async def test_make_api_request_omits_timeout_kwarg_when_not_given():
+    """Passing timeout=None straight to httpx disables the timeout outright,
+    so an unset override must not appear in the call at all."""
+    from congress_api.core import client_handler as mod
+
+    response = MagicMock()
+    response.json.return_value = {"ok": True}
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=response)
+
+    with patch.object(mod, "ENABLE_CACHING", False):
+        await mod.make_api_request("/bill/119", _FakeCtx(_FakeAppContext(fake_client)), {})
+
+    assert "timeout" not in fake_client.get.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_make_api_request_captures_retry_after_and_rate_limit_headers():
+    import httpx
+    from congress_api.core import client_handler as mod
+
+    request = httpx.Request("GET", "https://api.congress.gov/v3/bill/119")
+    response = httpx.Response(
+        429, request=request,
+        headers={"Retry-After": "7", "X-RateLimit-Remaining": "0"},
+    )
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(return_value=response)
+
+    with patch.object(mod, "ENABLE_CACHING", False):
+        result = await mod.make_api_request(
+            "/bill/119", _FakeCtx(_FakeAppContext(fake_client)), {})
+
+    assert result["status_code"] == 429
+    assert result["retry_after"] == "7"
+    assert result["rate_limit_remaining"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_make_api_request_reports_timeout_distinctly():
+    """A real httpx timeout must be classifiable as API_TIMEOUT downstream,
+    not collapsed into the generic 'Network error' message."""
+    import httpx
+    from congress_api.core import client_handler as mod
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=httpx.ReadTimeout("timed out"))
+
+    with patch.object(mod, "ENABLE_CACHING", False):
+        result = await mod.make_api_request(
+            "/bill/119", _FakeCtx(_FakeAppContext(fake_client)), {}, timeout=8.0)
+
+    assert "timeout" in result["error"].lower()
+    assert "status_code" not in result
+
+
+@pytest.mark.asyncio
+async def test_wrapper_classifies_real_timeout_as_api_timeout():
+    """End-to-end through DefensiveAPIWrapper: the distinct timeout message
+    from make_api_request must classify as API_TIMEOUT."""
+    import httpx
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=httpx.ReadTimeout("timed out"))
+    ctx = _FakeCtx(_FakeAppContext(fake_client))
+
+    with patch("congress_api.core.client_handler.ENABLE_CACHING", False), \
+            patch.object(mod.asyncio, "sleep", AsyncMock()):
+        with pytest.raises(CongressionalAPIError) as ei:
+            await mod.safe_congressional_request("/bill/119", ctx, {},
+                                                 endpoint_type="default")
+
+    assert ei.value.error_response.error_code == "API_TIMEOUT"

--- a/tests/test_retry_after.py
+++ b/tests/test_retry_after.py
@@ -57,25 +57,25 @@ async def test_429_sleeps_for_retry_after_seconds():
 
 
 @pytest.mark.asyncio
-async def test_429_retry_after_is_capped_at_max_retry_delay():
-    """A large/malformed Retry-After can't stall a tool call past the
-    endpoint's configured cap."""
+async def test_429_retry_after_beyond_cap_gives_up_instead_of_retrying():
+    """A Retry-After longer than the endpoint's max_retry_delay means the key
+    is throttled well past what we're willing to block a tool call for.
+    Sleeping the capped value anyway would just spend the remaining retries
+    hitting the same still-throttled key again, so give up on the first
+    failure instead of retrying at all."""
     from congress_api.core import api_wrapper as mod
     from congress_api.core.exceptions import CongressionalAPIError
 
-    sleep_calls = []
-
-    async def fake_sleep(seconds):
-        sleep_calls.append(seconds)
-
-    with patch.object(mod, "make_api_request",
-                      AsyncMock(return_value=_rate_limited(retry_after="120"))), \
-            patch.object(mod.asyncio, "sleep", fake_sleep):
-        with pytest.raises(CongressionalAPIError):
+    mock = AsyncMock(return_value=_rate_limited(retry_after="120"))
+    with patch.object(mod, "make_api_request", mock), \
+            patch.object(mod.asyncio, "sleep", AsyncMock()) as sleep_mock:
+        with pytest.raises(CongressionalAPIError) as ei:
             await mod.safe_congressional_request("/bill/119", FakeContext(), {},
                                                  endpoint_type="default")  # max_retry_delay=5.0
 
-    assert sleep_calls and all(s <= 5.0 for s in sleep_calls)
+    assert mock.await_count == 1
+    sleep_mock.assert_not_awaited()
+    assert ei.value.error_response.error_code == "RATE_LIMIT_EXCEEDED"
 
 
 @pytest.mark.asyncio
@@ -120,6 +120,57 @@ async def test_rate_limit_remaining_surfaced_when_exhausted():
     err = ei.value.error_response
     assert err.error_code == "RATE_LIMIT_EXCEEDED"
     assert "X-RateLimit-Remaining: 0" in err.message
+
+
+@pytest.mark.asyncio
+async def test_503_also_honors_retry_after():
+    """503 shares the Retry-After treatment with 429 (both are in
+    _RETRY_AFTER_STATUSES, mirroring the GovInfo client's {429, 503})."""
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+
+    def _unavailable(retry_after):
+        return {"error": "API request failed: 503", "status_code": 503,
+                "request_time": 0.01, "retry_after": retry_after,
+                "rate_limit_remaining": None}
+
+    sleep_calls = []
+
+    async def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    with patch.object(mod, "make_api_request",
+                      AsyncMock(return_value=_unavailable("2"))), \
+            patch.object(mod.asyncio, "sleep", fake_sleep):
+        with pytest.raises(CongressionalAPIError) as ei:
+            await mod.safe_congressional_request("/bill/119", FakeContext(), {},
+                                                 endpoint_type="bills")  # retry_count=3
+
+    assert sleep_calls == [2, 2, 2]
+    assert ei.value.error_response.error_code == "SERVER_ERROR"
+
+
+@pytest.mark.asyncio
+async def test_unusable_retry_after_falls_back_to_backoff_not_immediate_retry():
+    """A negative/NaN Retry-After (issue #58 code review) must not fire the
+    next attempt with ~0 delay against a key that's still being throttled --
+    it should be treated the same as no header at all."""
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+
+    sleep_calls = []
+
+    async def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    with patch.object(mod, "make_api_request",
+                      AsyncMock(return_value=_rate_limited(retry_after="-30"))), \
+            patch.object(mod.asyncio, "sleep", fake_sleep):
+        with pytest.raises(CongressionalAPIError):
+            await mod.safe_congressional_request("/bill/119", FakeContext(), {},
+                                                 endpoint_type="bills")
+
+    assert all(s >= 1.0 for s in sleep_calls)
 
 
 @pytest.mark.asyncio
@@ -188,7 +239,12 @@ async def test_make_api_request_forwards_timeout_kwarg_to_httpx():
         await mod.make_api_request("/bill/119", _FakeCtx(_FakeAppContext(fake_client)),
                                     {"limit": 5}, timeout=8.0)
 
-    assert fake_client.get.await_args.kwargs["timeout"] == 8.0
+    # A bare float would also loosen the 5s connect timeout the client was
+    # built with; only the read/write/pool legs should track the override.
+    import httpx
+    sent_timeout = fake_client.get.await_args.kwargs["timeout"]
+    assert sent_timeout == httpx.Timeout(8.0, connect=5.0)
+    assert sent_timeout.connect == 5.0
 
 
 @pytest.mark.asyncio
@@ -246,6 +302,49 @@ async def test_make_api_request_reports_timeout_distinctly():
 
     assert "timeout" in result["error"].lower()
     assert "status_code" not in result
+
+
+@pytest.mark.asyncio
+async def test_timeout_message_does_not_leak_endpoint_digits():
+    """The returned error message must not embed the endpoint: an endpoint
+    like /bill/118/hr/404 would false-positive api_wrapper's no-status-code
+    '400'/'404' substring scan and wrongly short-circuit retries on a plain
+    timeout (issue #58 code review)."""
+    import httpx
+    from congress_api.core import client_handler as mod
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=httpx.ReadTimeout("timed out"))
+
+    with patch.object(mod, "ENABLE_CACHING", False):
+        result = await mod.make_api_request(
+            "/bill/118/hr/404", _FakeCtx(_FakeAppContext(fake_client)), {})
+
+    assert "404" not in result["error"]
+    assert "400" not in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_timeout_on_endpoint_with_404_in_path_still_retries():
+    """End-to-end: a real timeout against an endpoint whose path contains
+    '404' must still use the endpoint's full retry budget, not short-circuit
+    the way an actual 404 status does."""
+    import httpx
+    from congress_api.core import api_wrapper as mod
+    from congress_api.core.exceptions import CongressionalAPIError
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=httpx.ReadTimeout("timed out"))
+    ctx = _FakeCtx(_FakeAppContext(fake_client))
+
+    with patch("congress_api.core.client_handler.ENABLE_CACHING", False), \
+            patch.object(mod.asyncio, "sleep", AsyncMock()):
+        with pytest.raises(CongressionalAPIError) as ei:
+            await mod.safe_congressional_request("/bill/118/hr/404", ctx, {},
+                                                 endpoint_type="bills")  # retry_count=3
+
+    assert fake_client.get.await_count == 4  # 1 initial + 3 retries, none skipped
+    assert ei.value.error_response.error_code == "API_TIMEOUT"
 
 
 @pytest.mark.asyncio

--- a/tests/test_retry_timing.py
+++ b/tests/test_retry_timing.py
@@ -1,0 +1,74 @@
+"""Issue #58 code review: the shared Retry-After parser must reject values
+that would fire a retry immediately (negative, zero) or hang forever
+(NaN/infinite) instead of sleeping them literally. This is the one
+implementation both congress_api/core/api_wrapper.py and
+congress_api/features/bill_text/client.py's GovInfo backoff use.
+"""
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from congress_api.core.retry_timing import parse_retry_after
+
+
+def test_numeric_seconds():
+    assert parse_retry_after("3") == 3.0
+    assert parse_retry_after("0.5") == 0.5
+
+
+def test_missing_or_empty_is_none():
+    assert parse_retry_after(None) is None
+    assert parse_retry_after("") is None
+
+
+def test_negative_seconds_rejected():
+    """A negative Retry-After must not fire the retry with zero/negative
+    delay -- that is strictly worse than no Retry-After handling."""
+    assert parse_retry_after("-30") is None
+
+
+def test_zero_seconds_rejected():
+    assert parse_retry_after("0") is None
+
+
+def test_nan_rejected():
+    """asyncio.sleep(float('nan')) never returns; NaN must not reach it."""
+    assert parse_retry_after("nan") is None
+
+
+def test_infinity_rejected():
+    assert parse_retry_after("inf") is None
+
+
+def test_garbage_string_is_none():
+    assert parse_retry_after("soon") is None
+
+
+def test_future_http_date_returns_positive_seconds():
+    from datetime import datetime, timedelta, timezone
+    from email.utils import format_datetime
+
+    future = datetime.now(timezone.utc) + timedelta(seconds=45)
+    value = format_datetime(future, usegmt=True)
+    seconds = parse_retry_after(value)
+    assert seconds is not None
+    assert 40 <= seconds <= 50
+
+
+def test_past_http_date_rejected():
+    """Clock skew or a stale cached 429 can carry a Retry-After date already
+    in the past; that must fall back to backoff, not sleep(0) or negative."""
+    assert parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT") is None
+
+
+def test_result_is_always_finite_and_positive():
+    """Every non-None result must be safe to hand straight to asyncio.sleep --
+    the property the unclamped original helper violated (a negative/NaN
+    value sailed through as-is)."""
+    for value in ["-30", "0", "nan", "inf", "-inf",
+                  "Wed, 21 Oct 2015 07:28:00 GMT", "garbage", None, ""]:
+        seconds = parse_retry_after(value)
+        if seconds is not None:
+            assert math.isfinite(seconds) and seconds > 0


### PR DESCRIPTION
## Summary
- `DefensiveAPIWrapper` retried 429/5xx on a fixed 1-5s exponential backoff regardless of what Congress.gov said — multiplying requests against an already-throttled key. It now reads `Retry-After` (seconds or an HTTP-date) on 429/503 and sleeps that, capped at each endpoint's `max_retry_delay`; falls back to backoff+jitter when the header is absent or unusable.
- Per-endpoint timeouts computed in `ENDPOINT_CONFIGS` were never passed to httpx — `make_api_request()` now accepts a `timeout` override and forwards it (as `httpx.Timeout(connect=5.0, read=timeout, ...)`, so it only widens the read leg, not connect/write/pool).
- `X-RateLimit-Remaining` is captured from the response headers and appended to the final error message when it's exhausted (`<= 0`).
- A real httpx timeout is now reported distinctly (contains "timeout") so it classifies as `API_TIMEOUT` instead of a generic "Network error" message, and no longer embeds the endpoint path (which could false-positive a substring scan on paths like `/bill/118/hr/404`).
- Extracted the Retry-After parser to `congress_api/core/retry_timing.py`, fixing an identical unclamped bug that existed in the GovInfo bill-text client (`bill_text/client.py`): a negative Retry-After fired immediately and a NaN value hung `asyncio.sleep()` forever. Both clients now share one fixed implementation.

## Assumptions Made
- Extended Retry-After handling to 503 as well as 429, matching the set the GovInfo client already backs off on.
- A Retry-After beyond the endpoint's `max_retry_delay` is capped and still retried (not abandoned) — matches `documentation/fulltext/03-data-sources.md`'s "respect Retry-After on both 429 and 503, capped at a maximum wait," and keeps both API clients on the same policy.
- Left each endpoint's `retry_count` (1-3) unchanged; "cap total attempts" is satisfied by the existing bound now that the pacing between attempts is honest.

## Quality gates
- [x] All tests passing (762 passed, 5 skipped; 2 pre-existing/unrelated failures in `test_registration_endpoint.py` — a missing async-plugin marker issue in an unrelated Starlette test, present on `master` before this branch)
- [x] Lint clean (no new violations — all remaining ruff findings in touched files are pre-existing style, confirmed via `git stash` diff against master)
- [x] Code critique: PASS (score 87, iteration 2 — iteration 1 found one blocking bug, since fixed and re-verified)
- [x] No regressions

## Known Limitations
- None.

Closes #58