### PR TITLE
Schema honesty: document required params in bucket tool docstrings

### DIFF
--- a/congress_api/features/amendments_tool.py
+++ b/congress_api/features/amendments_tool.py
@@ -95,7 +95,16 @@ async def amendments(
     
     CONTENT OPERATIONS:
     - get_amendment_text: Full amendment text and purpose
-    
+
+    REQUIRED PARAMETERS (the schema marks every parameter optional because
+    one shared schema covers every operation -- these operations fail
+    without the values below):
+    • congress + amendment_type + amendment_number -- get_amendment_details,
+      get_amendment_sponsors, get_amendment_actions, get_amendment_amendments,
+      get_amendment_text (get_amendment_text also requires congress >= 117;
+      text isn't available for earlier Congresses)
+    (get_amendments, search_amendments need none of the above)
+
     Args:
         operation: Specific operation to perform (see list above)
         congress: Congress number (118 for current, 119 for next)

--- a/congress_api/features/bills_tool.py
+++ b/congress_api/features/bills_tool.py
@@ -128,18 +128,23 @@ async def bills(
     REQUIRED PARAMETERS (the schema marks every parameter optional because
     one shared schema covers every operation -- these operations fail
     without the values below):
-    • congress + bill_type + bill_number (or bill_id, which is parsed into
-      those three) -- get_bill_details, get_bill_titles, get_bill_subjects,
-      get_bill_text, get_bill_text_versions, get_bill_summaries,
-      get_bill_related_bills, get_bill_amendments, get_bill_actions,
-      get_bill_committees, get_bill_cosponsors
+    • congress + bill_type + bill_number -- get_bill_details,
+      get_bill_titles, get_bill_subjects, get_bill_text,
+      get_bill_text_versions, get_bill_summaries, get_bill_related_bills,
+      get_bill_amendments, get_bill_actions, get_bill_committees,
+      get_bill_cosponsors. bill_id can substitute for bill_type +
+      bill_number, but only supplies congress itself when the reference
+      embeds one ('hr1234-118', 'HR 1234, 118th Congress') -- a bare
+      'HR 1234' still needs an explicit congress or the call fails the
+      same as if bill_id were omitted entirely.
     • fromDateTime -- get_bills_by_date_range
     (search_bills, get_bills, get_recent_bills need none of the above)
 
     Args:
         operation: Specific operation to perform (see list above)
         bill_id: Flexible bill reference (e.g., 'HR 1234', 'H.R. 1234, 118th Congress', 'hr1234-118')
-                 Automatically parsed to populate congress, bill_type, bill_number
+                 Parsed to populate bill_type and bill_number always, and congress
+                 only if the reference embeds one -- pass congress explicitly otherwise
         keywords: Search keywords for content and metadata
         congress: Congress number (118 for current, 119 for next)
         bill_type: hr, s, hjres, sjres, hconres, sconres, hres, sres
@@ -152,10 +157,12 @@ async def bills(
         Formatted results specific to requested operation
         
     Examples:
-        Using flexible bill_id:
-        {"operation": "get_bill_details", "bill_id": "HR 1234"}
-        {"operation": "get_bill_details", "bill_id": "H.R. 1234, 118th Congress"}  
+        Using flexible bill_id (congress embedded in the reference itself):
+        {"operation": "get_bill_details", "bill_id": "H.R. 1234, 118th Congress"}
         {"operation": "get_bill_details", "bill_id": "hr1234-118"}
+
+        bill_id without an embedded congress still needs one explicitly:
+        {"operation": "get_bill_details", "bill_id": "HR 1234", "congress": 118}
         
         Traditional parameters still work:
         {"operation": "get_bill_details", "congress": 118, "bill_type": "hr", "bill_number": 1234}

--- a/congress_api/features/bills_tool.py
+++ b/congress_api/features/bills_tool.py
@@ -111,8 +111,10 @@ async def bills(
     Comprehensive Bills Tool - All bill operations in one focused interface.
     
     FLEXIBLE BILL IDENTIFICATION (NEW):
-    Use bill_id for natural language references like 'HR 1234', 'H.R. 1234, 118th Congress', 
-    'hr1234-118', 'S 456', etc. Automatically parses to congress/bill_type/bill_number.
+    Use bill_id for natural language references like 'HR 1234',
+    'H.R. 1234, 118th Congress', 'hr1234-118', 'S 456', etc. Always parses
+    to bill_type/bill_number; parses to congress too only when the
+    reference embeds one (see REQUIRED PARAMETERS below).
     
     CORE OPERATIONS:
     • Search & Discovery: search_bills, get_bills, get_recent_bills
@@ -143,8 +145,9 @@ async def bills(
     Args:
         operation: Specific operation to perform (see list above)
         bill_id: Flexible bill reference (e.g., 'HR 1234', 'H.R. 1234, 118th Congress', 'hr1234-118')
-                 Parsed to populate bill_type and bill_number always, and congress
-                 only if the reference embeds one -- pass congress explicitly otherwise
+                 Parsed to populate bill_type and bill_number always, and
+                 congress only if the reference embeds one -- pass congress
+                 explicitly otherwise
         keywords: Search keywords for content and metadata
         congress: Congress number (118 for current, 119 for next)
         bill_type: hr, s, hjres, sjres, hconres, sconres, hres, sres

--- a/congress_api/features/bills_tool.py
+++ b/congress_api/features/bills_tool.py
@@ -124,7 +124,18 @@ async def bills(
     • Relationships: get_bill_related_bills, get_bill_amendments
     • Legislative Process: get_bill_actions, get_bill_committees, get_bill_cosponsors
     • Date-Based: get_bills_by_date_range
-    
+
+    REQUIRED PARAMETERS (the schema marks every parameter optional because
+    one shared schema covers every operation -- these operations fail
+    without the values below):
+    • congress + bill_type + bill_number (or bill_id, which is parsed into
+      those three) -- get_bill_details, get_bill_titles, get_bill_subjects,
+      get_bill_text, get_bill_text_versions, get_bill_summaries,
+      get_bill_related_bills, get_bill_amendments, get_bill_actions,
+      get_bill_committees, get_bill_cosponsors
+    • fromDateTime -- get_bills_by_date_range
+    (search_bills, get_bills, get_recent_bills need none of the above)
+
     Args:
         operation: Specific operation to perform (see list above)
         bill_id: Flexible bill reference (e.g., 'HR 1234', 'H.R. 1234, 118th Congress', 'hr1234-118')

--- a/congress_api/features/buckets/committee_intelligence.py
+++ b/congress_api/features/buckets/committee_intelligence.py
@@ -228,7 +228,8 @@ async def committee_intelligence(
       get_committee_report_text_versions, get_committee_report_content
     • congress + chamber + jacket_number -- get_committee_print_details,
       get_committee_print_text_versions
-    • congress + chamber + committee_code -- get_committee_meetings_by_committee
+    • congress + chamber + committee_code --
+      get_committee_meetings_by_committee
     • congress + chamber + event_id -- get_committee_meeting_details
     (get_latest_committee_reports/prints/meetings and every search_*
     operation need none of the above)

--- a/congress_api/features/buckets/committee_intelligence.py
+++ b/congress_api/features/buckets/committee_intelligence.py
@@ -216,6 +216,23 @@ async def committee_intelligence(
     • get_latest/by_congress/by_chamber/by_committee, get_meeting_details
     • search_committee_meetings - Process intelligence with scheduling data
 
+    REQUIRED PARAMETERS (the schema marks every parameter optional because
+    one shared schema covers every operation -- these operations fail
+    without the values below):
+    • congress -- get_committee_reports_by_congress,
+      get_committee_prints_by_congress, get_committee_meetings_by_congress
+    • congress + chamber -- get_committee_prints_by_congress_and_chamber,
+      get_committee_meetings_by_congress_and_chamber
+    • congress + report_type -- get_committee_reports_by_congress_and_type
+    • congress + report_type + report_number -- get_committee_report_details,
+      get_committee_report_text_versions, get_committee_report_content
+    • congress + chamber + jacket_number -- get_committee_print_details,
+      get_committee_print_text_versions
+    • congress + chamber + committee_code -- get_committee_meetings_by_committee
+    • congress + chamber + event_id -- get_committee_meeting_details
+    (get_latest_committee_reports/prints/meetings and every search_*
+    operation need none of the above)
+
     Key params: operation, congress, chamber, committee_code, report_type, event_id
     Returns structured committee data with enhanced metadata and content chunking.
     """

--- a/congress_api/features/buckets/records_and_hearings.py
+++ b/congress_api/features/buckets/records_and_hearings.py
@@ -213,6 +213,21 @@ async def records_and_hearings(
     HEARINGS (5 operations):
     • search_hearings, get_hearings_by_congress/chamber, get_hearing_details/content
 
+    REQUIRED PARAMETERS (the schema marks every parameter optional because
+    one shared schema covers every operation -- these operations fail
+    without the values below):
+    • congress -- get_hearings_by_congress
+    • congress + chamber -- get_hearings_by_congress_and_chamber
+    • congress + chamber + jacket_number -- get_hearing_details, get_hearing_content
+    • congress + communication_type + communication_number --
+      get_senate_communication_details, get_house_communication_details
+    • congress + chamber + communication_type + communication_number --
+      get_committee_communication_details
+    • requirement_number -- get_house_requirement_details,
+      get_house_requirement_matching_communications
+    (search_congressional_record/daily/bound and every other search_*
+    operation need none of the above)
+
     Key params: operation, year/month/day, keywords, congress, chamber, jacket_number
     Returns structured record/hearing data with full text content and metadata.
     """

--- a/congress_api/features/buckets/records_and_hearings.py
+++ b/congress_api/features/buckets/records_and_hearings.py
@@ -218,7 +218,8 @@ async def records_and_hearings(
     without the values below):
     • congress -- get_hearings_by_congress
     • congress + chamber -- get_hearings_by_congress_and_chamber
-    • congress + chamber + jacket_number -- get_hearing_details, get_hearing_content
+    • congress + chamber + jacket_number -- get_hearing_details,
+      get_hearing_content
     • congress + communication_type + communication_number --
       get_senate_communication_details, get_house_communication_details
     • congress + chamber + communication_type + communication_number --

--- a/congress_api/features/buckets/research_and_professional.py
+++ b/congress_api/features/buckets/research_and_professional.py
@@ -126,6 +126,13 @@ async def research_and_professional(
     • search_crs_reports - CRS reports: exact report_number lookup, or a
       title filter over the 250 most recently updated reports (not full-text)
 
+    REQUIRED PARAMETERS (the schema marks every parameter optional because
+    one shared schema covers every operation -- these operations fail
+    without the values below):
+    • keywords -- search_congresses
+    • keywords or report_number (at least one) -- search_crs_reports
+    (get_congress_info, get_congress_info_enhanced need none of the above)
+
     Key params: operation, congress, keywords, report_number, start_year, end_year
     Returns professional-grade research data with enhanced analytics and historical insights.
     """

--- a/congress_api/features/buckets/voting_and_nominations.py
+++ b/congress_api/features/buckets/voting_and_nominations.py
@@ -197,6 +197,19 @@ async def voting_and_nominations(
     • search_nominations, get_latest_nominations, get_nomination_details
     • get_nomination_actions/committees/hearings/nominees, get_nominations_by_congress
 
+    REQUIRED PARAMETERS (the schema marks every parameter optional because
+    one shared schema covers every operation -- these operations fail
+    without the values below):
+    • congress -- get_house_votes_by_congress, get_nominations_by_congress
+    • congress + session -- get_house_votes_by_session
+    • congress + session + vote_number -- get_house_vote_details(_enhanced),
+      get_house_vote_member_votes(_xml)
+    • congress + nomination_number -- get_nomination_details,
+      get_nomination_actions, get_nomination_committees,
+      get_nomination_hearings
+    • congress + nomination_number + ordinal -- get_nomination_nominees
+    (search_nominations, get_latest_nominations need none of the above)
+
     Key params: operation, congress, session, vote_number, keywords, nomination_number
     Returns structured vote/nomination data with member details and legislative actions.
     """

--- a/congress_api/features/treaties_and_summaries_tool.py
+++ b/congress_api/features/treaties_and_summaries_tool.py
@@ -88,7 +88,14 @@ async def treaties_and_summaries(
     
     SUMMARIES:
     - search_summaries: Search bill summaries by keywords and congress
-    
+
+    REQUIRED PARAMETERS (the schema marks every parameter optional because
+    one shared schema covers every operation -- these operations fail
+    without the values below):
+    • congress + treaty_number -- get_treaty_actions, get_treaty_committees,
+      get_treaty_text
+    (search_treaties, search_summaries need none of the above)
+
     Args:
         operation: Specific operation to perform (see list above)
         congress: Congress number (118 for current, 119 for next)

--- a/tests/test_invoke_all_operations_with_defaults.py
+++ b/tests/test_invoke_all_operations_with_defaults.py
@@ -25,7 +25,13 @@ operation genuinely requires it. When schema defaults trip a parameter-
 shaped validation error (invalid_parameter and the handful of dedicated
 invalid_*_type/congress_too_old_for_text codes), this test also asserts
 that the required parameter is actually named in the tool's own docstring
--- the only channel available to tell a caller before it tries.
+-- the only channel available to tell a caller before it tries. Coverage
+caveat: several bills-bucket detail operations (get_bill_titles,
+get_bill_subjects, get_bill_text, etc.) return a bare prose string on
+error rather than the section-9 envelope, so this check -- like the
+crash check above it -- only reaches them via the JSON-string branch,
+and not at all when the error is prose. Only get_bill_details and
+get_bill_actions in that family are actually envelope-shaped today.
 """
 import inspect
 import os
@@ -157,8 +163,11 @@ _OPERATIONS = _list_operations()
 
 # Issue #69: a handful of error codes name the offending parameter in the
 # code itself rather than via the generic invalid_parameter -> detail.parameter
-# channel (see congress_api/core/exceptions.py's dedicated CommonErrors.*
-# helpers). Map each straight to the parameter a bucket docstring must name.
+# channel: invalid_bill_type/invalid_amendment_type/invalid_communication_type
+# come from dedicated CommonErrors.* helpers (congress_api/core/exceptions.py);
+# congress_too_old_for_text is a domain-specific inline check in
+# congress_api/features/buckets/amendments/api.py with no such helper. Map
+# each straight to the parameter a bucket docstring must name.
 _CODE_TO_PARAM = {
     "invalid_bill_type": "bill_type",
     "invalid_amendment_type": "amendment_type",
@@ -228,13 +237,31 @@ async def test_operation_invocable_with_schema_defaults(tool_name, operation, to
         missing_param = detail.get("parameter")
     if missing_param is not None:
         doc = tool_fn.__doc__ or ""
-        assert missing_param in doc, (
-            f"{tool_name}::{operation} rejected schema defaults with an "
-            f"invalid '{missing_param}', but the {tool_name} tool's "
-            f"docstring never names '{missing_param}' as required -- a "
-            f"caller reading the schema has no way to learn that "
-            f"beforehand (issue #69)."
-        )
+        # Bucket docstrings carry a "REQUIRED PARAMETERS" section listing
+        # exactly which operations need which params (issue #69). Anchor the
+        # check there when it exists so a stray mention of the parameter name
+        # elsewhere in the docstring (e.g. a generic Args: line) can't paper
+        # over a missing entry for THIS operation; fall back to the whole
+        # docstring for flat tools, which have no such section.
+        marker = "REQUIRED PARAMETERS"
+        required_section = doc[doc.index(marker):] if marker in doc else doc
+        if code == "congress_too_old_for_text":
+            assert missing_param in required_section, (
+                f"{tool_name}::{operation} rejected schema defaults because "
+                f"the dummy congress value is out of the supported range, "
+                f"but the {tool_name} tool's docstring never names "
+                f"'{missing_param}' as required in the first place -- a "
+                f"caller has no way to learn it needs a real congress value "
+                f"at all (issue #69)."
+            )
+        else:
+            assert missing_param in required_section, (
+                f"{tool_name}::{operation} rejected schema defaults with an "
+                f"invalid '{missing_param}', but the {tool_name} tool's "
+                f"docstring never names '{missing_param}' as required -- a "
+                f"caller reading the schema has no way to learn that "
+                f"beforehand (issue #69)."
+            )
 
 
 def test_operations_were_discovered():

--- a/tests/test_invoke_all_operations_with_defaults.py
+++ b/tests/test_invoke_all_operations_with_defaults.py
@@ -18,6 +18,14 @@ every request path funnels through regardless of which of the many
 `safe_*_request`/`make_api_request` local import aliases a given handler
 uses -- so every operation gets a uniformly empty-but-valid JSON response
 without needing per-operation response fixtures.
+
+Issue #69 follow-up: for bucket tools, one schema is shared across every
+operation, so every parameter is marked optional even when a specific
+operation genuinely requires it. When schema defaults trip a parameter-
+shaped validation error (invalid_parameter and the handful of dedicated
+invalid_*_type/congress_too_old_for_text codes), this test also asserts
+that the required parameter is actually named in the tool's own docstring
+-- the only channel available to tell a caller before it tries.
 """
 import inspect
 import os
@@ -147,6 +155,17 @@ def _list_operations():
 
 _OPERATIONS = _list_operations()
 
+# Issue #69: a handful of error codes name the offending parameter in the
+# code itself rather than via the generic invalid_parameter -> detail.parameter
+# channel (see congress_api/core/exceptions.py's dedicated CommonErrors.*
+# helpers). Map each straight to the parameter a bucket docstring must name.
+_CODE_TO_PARAM = {
+    "invalid_bill_type": "bill_type",
+    "invalid_amendment_type": "amendment_type",
+    "invalid_communication_type": "communication_type",
+    "congress_too_old_for_text": "congress",
+}
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -169,6 +188,8 @@ async def test_operation_invocable_with_schema_defaults(tool_name, operation, to
     with patch.object(httpx.AsyncClient, "get", return_value=_FakeResponse()):
         result = await tool_fn(ctx, **kwargs)
 
+    code = None
+    detail = None
     if hasattr(result, "success"):
         if result.success is False:
             err = getattr(result, "error", None)
@@ -184,6 +205,8 @@ async def test_operation_invocable_with_schema_defaults(tool_name, operation, to
                                     "general_error", "general_api_failure"), (
                 f"{tool_name}::{operation} crashed: {err.message}"
             )
+            code = err.code
+            detail = err.detail
     elif isinstance(result, str) and result.lstrip().startswith("{"):
         try:
             payload = _json.loads(result).get("error") or {}
@@ -192,6 +215,25 @@ async def test_operation_invocable_with_schema_defaults(tool_name, operation, to
         assert payload.get("code") not in ("internal_error", "server_error",
                                            "general_error", "general_api_failure"), (
             f"{tool_name}::{operation} crashed: {payload.get('message')}"
+        )
+        code = payload.get("code")
+        detail = payload.get("detail")
+
+    # Issue #69: a bucket's shared schema marks every parameter optional,
+    # so when schema defaults trip a parameter-shaped validation error, the
+    # only place a caller could have learned that parameter was required is
+    # the tool's own docstring. Assert it's actually named there.
+    missing_param = _CODE_TO_PARAM.get(code)
+    if missing_param is None and code == "invalid_parameter" and detail:
+        missing_param = detail.get("parameter")
+    if missing_param is not None:
+        doc = tool_fn.__doc__ or ""
+        assert missing_param in doc, (
+            f"{tool_name}::{operation} rejected schema defaults with an "
+            f"invalid '{missing_param}', but the {tool_name} tool's "
+            f"docstring never names '{missing_param}' as required -- a "
+            f"caller reading the schema has no way to learn that "
+            f"beforehand (issue #69)."
         )
 
 

--- a/tests/test_invoke_all_operations_with_defaults.py
+++ b/tests/test_invoke_all_operations_with_defaults.py
@@ -163,11 +163,14 @@ _OPERATIONS = _list_operations()
 
 # Issue #69: a handful of error codes name the offending parameter in the
 # code itself rather than via the generic invalid_parameter -> detail.parameter
-# channel: invalid_bill_type/invalid_amendment_type/invalid_communication_type
-# come from dedicated CommonErrors.* helpers (congress_api/core/exceptions.py);
-# congress_too_old_for_text is a domain-specific inline check in
-# congress_api/features/buckets/amendments/api.py with no such helper. Map
-# each straight to the parameter a bucket docstring must name.
+# channel. invalid_bill_type (congress_api/features/buckets/bills/api.py) and
+# invalid_communication_type (congress_api/features/house_communications.py)
+# go through the CommonErrors.* helpers of the same name in
+# congress_api/core/exceptions.py; invalid_amendment_type and
+# congress_too_old_for_text are both inline APIErrorResponse(...) constructions
+# in congress_api/features/buckets/amendments/api.py (CommonErrors also
+# defines an invalid_amendment_type helper, but nothing calls it). Map each
+# code straight to the parameter a bucket docstring must name.
 _CODE_TO_PARAM = {
     "invalid_bill_type": "bill_type",
     "invalid_amendment_type": "amendment_type",
@@ -238,13 +241,22 @@ async def test_operation_invocable_with_schema_defaults(tool_name, operation, to
     if missing_param is not None:
         doc = tool_fn.__doc__ or ""
         # Bucket docstrings carry a "REQUIRED PARAMETERS" section listing
-        # exactly which operations need which params (issue #69). Anchor the
-        # check there when it exists so a stray mention of the parameter name
-        # elsewhere in the docstring (e.g. a generic Args: line) can't paper
-        # over a missing entry for THIS operation; fall back to the whole
-        # docstring for flat tools, which have no such section.
-        marker = "REQUIRED PARAMETERS"
-        required_section = doc[doc.index(marker):] if marker in doc else doc
+        # exactly which operations need which params (issue #69), always
+        # followed by an "Args:" or "Key params:" line. Bound the check to
+        # that section -- start AND end -- so a stray mention of the same
+        # word in the trailing Args:/Key params: summary (which pre-dates
+        # this fix and isn't per-operation) can't paper over a missing or
+        # edited-away entry in the actual required-params list. Fall back to
+        # the whole docstring for flat tools, which have no such section.
+        start_marker = "REQUIRED PARAMETERS"
+        if start_marker in doc:
+            start = doc.index(start_marker)
+            end_positions = [doc.find(m, start) for m in ("Args:", "Key params:")]
+            end_positions = [p for p in end_positions if p != -1]
+            end = min(end_positions) if end_positions else len(doc)
+            required_section = doc[start:end]
+        else:
+            required_section = doc
         if code == "congress_too_old_for_text":
             assert missing_param in required_section, (
                 f"{tool_name}::{operation} rejected schema defaults because "
@@ -272,3 +284,29 @@ def test_operations_were_discovered():
         f"expected ~96 (tool, operation) pairs, found {len(_OPERATIONS)} -- "
         "audit_tool_schemas' dispatch parsing may have regressed"
     )
+
+
+# Every bucket tool with a required-but-schema-optional parameter (issue #69).
+# The per-operation check above only fires for the subset of these that a
+# schema-defaults call happens to trip an error for -- it can't detect the
+# heading disappearing from a bucket entirely (e.g. a docstring rewrite that
+# drops the section wholesale), since without the marker it falls back to
+# scanning the whole docstring, and each bucket's pre-existing "Key params:"/
+# "Args:" trailer already happens to mention most of these words anyway.
+# This is a blunt backstop for exactly that gap.
+_BUCKETS_WITH_REQUIRED_PARAMS = (
+    "bills", "amendments", "records_and_hearings", "committee_intelligence",
+    "research_and_professional", "voting_and_nominations", "treaties_and_summaries",
+)
+
+
+def test_bucket_docstrings_have_required_parameters_section():
+    tools = {t.name: t.fn for t in mcp._tool_manager.list_tools()}
+    for name in _BUCKETS_WITH_REQUIRED_PARAMS:
+        doc = tools[name].__doc__ or ""
+        assert "REQUIRED PARAMETERS" in doc, (
+            f"{name}'s docstring lost its REQUIRED PARAMETERS section -- "
+            f"the per-operation check above falls back to scanning the "
+            f"whole docstring when this heading is missing, which is too "
+            f"weak to catch that on its own (issue #69)."
+        )


### PR DESCRIPTION
## Summary
- Bucket tools (`bills`, `amendments`, `records_and_hearings`, `committee_intelligence`, `research_and_professional`, `voting_and_nominations`, `treaties_and_summaries`) share one schema across every operation, so every parameter is marked optional even when a specific operation's handler genuinely requires it. A model reading the schema had no way to know a bare call needed those values until it tried and got an error.
- Added a "REQUIRED PARAMETERS" section to each of the 7 bucket docstrings, naming exactly which operations need which parameters. Verified against every dispatched handler's real signature (`inspect.signature`, no default = required) — not just the subset that happened to surface as `invalid_parameter` in the existing schema-defaults smoke test — and confirmed complete, necessary, and sufficient by dropping/supplying each documented parameter individually across all 62 documented operations.
- Fixed a false claim in the `bills` docstring: `bill_id` only supplies `congress` when the reference embeds one (`'hr1234-118'`, `'..., 118th Congress'`); a bare `'HR 1234'` still needs an explicit `congress` or the call fails the same as if `bill_id` were omitted. The docstring's own example previously demonstrated a call that would crash.
- Extended `tests/test_invoke_all_operations_with_defaults.py` per the issue's acceptance criteria: when a schema-defaults call trips a parameter-shaped error (`invalid_parameter`, or the dedicated `invalid_bill_type`/`invalid_amendment_type`/`invalid_communication_type`/`congress_too_old_for_text` codes), it now asserts the tool's own docstring names that parameter — pinning the fix so a future undocumented required-but-schema-optional param fails CI instead of silently reproducing this issue. Added a small backstop test asserting each bucket docstring still carries the `REQUIRED PARAMETERS` heading at all.

## Assumptions Made
- Issue #69 named 5 buckets explicitly; while implementing I found the identical defect in 2 more (`voting_and_nominations`, `treaties_and_summaries`) via the same signature-inspection method, and documented those too rather than filing a separate issue for what's the same root cause.
- The issue's acceptance criteria only requires documentation; a deeper code-level fix (structured `invalid_parameter` instead of a raw crash on a truly bare call omitting a required param) was explicitly out of scope per the issue's own framing ("the description is the only channel") — filed as follow-up #71 instead of fixed here.

## Quality gates
- [x] All tests passing (`tests/test_invoke_all_operations_with_defaults.py`: 97 passed; full suite: matches the recorded `KNOWN_FAILURES.md` baseline exactly, nothing new)
- [x] Lint clean (no new ruff violations on any touched file — verified by comparing counts against `origin/master`)
- [x] Schema-drift audit clean (`scripts/audit_tool_schemas.py --check` exits 0)
- [x] Code critique: PASS WITH CHANGES (two rounds; both blocking issues from round 1 fixed and re-verified; round 2's non-blocking findings addressed except one noted below)
- [x] No regressions

## Known Limitations
- The new test's per-operation check anchors to each docstring's `REQUIRED PARAMETERS` section (bounded start-to-end) but can't yet distinguish "this exact operation's own bullet names the param" from "the param name appears somewhere in the section because a *different* operation also needs it" — e.g. if `communication_type` were dropped from `get_senate_communication_details`'s bullet but stayed in `get_committee_communication_details`'s, the check wouldn't catch it. True per-bullet precision would need parsing the section's bullet structure. The documentation itself was verified exhaustively by hand (complete/necessary/sufficient against every real handler signature); this test is a regression backstop, not the primary correctness guarantee.
- A deeper, related bug (bucket ops crash with a raw `ToolError` on a truly bare call that omits a required param entirely, rather than returning a structured error) is tracked separately in #71 — out of scope for this doc-only fix.

Closes #69
