### PR TITLE
Fix NoChamber/Unknown-nominees cosmetic display bugs

### DIFF
--- a/congress_api/features/committees.py
+++ b/congress_api/features/committees.py
@@ -495,7 +495,11 @@ async def get_committee_nominations(
             url = nomination.get("url", "No URL available")
             update_date = nomination.get("updateDate", "Unknown")
             
-            # Get nominees
+            # Get nominees. The committee-level listing doesn't carry a
+            # `nominees` array with firstName/lastName -- that shape only
+            # appears on the nomination detail endpoint. Here the nominee's
+            # name and position come embedded in `description` instead, so
+            # read that; omit the line entirely rather than claim "Unknown".
             nominees = nomination.get("nominees", [])
             nominee_names = []
             for nominee in nominees:
@@ -504,11 +508,14 @@ async def get_committee_nominations(
                 full_name = f"{first_name} {last_name}".strip()
                 if full_name:
                     nominee_names.append(full_name)
-            
-            nominee_text = ", ".join(nominee_names) if nominee_names else "Unknown nominees"
-            
+
+            description = nomination.get("description")
+
             result.append(f"\n**Nomination {number}** (Congress {congress})")
-            result.append(f"Nominees: {nominee_text}")
+            if nominee_names:
+                result.append(f"Nominees: {', '.join(nominee_names)}")
+            elif description:
+                result.append(f"Description: {description}")
             result.append(f"Updated: {update_date}")
             result.append(f"URL: {url}")
         

--- a/congress_api/features/committees.py
+++ b/congress_api/features/committees.py
@@ -503,13 +503,15 @@ async def get_committee_nominations(
             nominees = nomination.get("nominees", [])
             nominee_names = []
             for nominee in nominees:
+                if not isinstance(nominee, dict):
+                    continue
                 first_name = nominee.get("firstName", "")
                 last_name = nominee.get("lastName", "")
                 full_name = f"{first_name} {last_name}".strip()
                 if full_name:
                     nominee_names.append(full_name)
 
-            description = nomination.get("description")
+            description = (nomination.get("description") or "").strip()
 
             result.append(f"\n**Nomination {number}** (Congress {congress})")
             if nominee_names:

--- a/congress_api/features/hearings.py
+++ b/congress_api/features/hearings.py
@@ -16,10 +16,21 @@ logger.setLevel(logging.DEBUG)
 
 # --- Formatting Helpers ---
 
+def _display_chamber(chamber: Optional[str]) -> str:
+    """Render a hearing's chamber value for display.
+
+    Congress.gov returns the literal token "NoChamber" for hearings held
+    by joint (chamber-agnostic) committees -- show "Joint" instead of
+    leaking that internal API token to users.
+    """
+    if chamber == "NoChamber":
+        return "Joint"
+    return chamber or "N/A"
+
 def format_hearing_item(hearing_item: Dict[str, Any]) -> str:
     """Formats a single hearing item for display in a list."""
     lines = [
-        f"Chamber: {hearing_item.get('chamber', 'N/A')}",
+        f"Chamber: {_display_chamber(hearing_item.get('chamber'))}",
         f"Congress: {hearing_item.get('congress', 'N/A')}",
         f"Jacket Number: {hearing_item.get('jacketNumber', 'N/A')}",
         f"Update Date: {hearing_item.get('updateDate', 'N/A')}",
@@ -31,7 +42,7 @@ def format_hearing_detail(hearing_item: Dict[str, Any]) -> str:
     """Formats detailed information for a single hearing."""
     lines = [
         f"Title: {hearing_item.get('title', 'N/A')}",
-        f"Chamber: {hearing_item.get('chamber', 'N/A')}",
+        f"Chamber: {_display_chamber(hearing_item.get('chamber'))}",
         f"Congress: {hearing_item.get('congress', 'N/A')}",
         f"Citation: {hearing_item.get('citation', 'N/A')}",
         f"Jacket Number: {hearing_item.get('jacketNumber', 'N/A')}",

--- a/congress_api/features/hearings.py
+++ b/congress_api/features/hearings.py
@@ -20,11 +20,15 @@ def _display_chamber(chamber: Optional[str]) -> str:
     """Render a hearing's chamber value for display.
 
     Congress.gov returns the literal token "NoChamber" for hearings held
-    by joint (chamber-agnostic) committees -- show "Joint" instead of
-    leaking that internal API token to users.
+    by joint (chamber-agnostic) committees. Show "Joint" so that reads
+    clearly, but keep "nochamber" visible too -- it's the exact value
+    ParameterValidator.validate_chamber() accepts for
+    get_hearings_by_congress_and_chamber/get_hearing_details, and a
+    client copying "Joint" alone back into those tools would get
+    rejected.
     """
-    if chamber == "NoChamber":
-        return "Joint"
+    if isinstance(chamber, str) and chamber.strip().lower() == "nochamber":
+        return "Joint (nochamber)"
     return chamber or "N/A"
 
 def format_hearing_item(hearing_item: Dict[str, Any]) -> str:

--- a/tests/test_issue_59_display_fixes.py
+++ b/tests/test_issue_59_display_fixes.py
@@ -196,3 +196,86 @@ async def test_committee_nominations_omits_line_when_no_nominee_info():
     assert "Unknown nominees" not in out
     assert "Nominees:" not in out
     assert "Description:" not in out
+
+
+@pytest.mark.asyncio
+async def test_committee_nominations_empty_nominees_list_uses_description():
+    # An empty `nominees: []` (present but empty) must behave the same as
+    # a missing key -- fall back to `description`, not print "Unknown".
+    page = {
+        "nominations": [
+            {
+                "citation": "PN3-1",
+                "congress": 119,
+                "number": 3,
+                "nominees": [],
+                "description": "A real nominee description.",
+                "updateDate": "2026-01-01",
+                "url": "u",
+            },
+        ],
+        "pagination": {"count": 1},
+    }
+
+    async def _se(endpoint, ctx, params=None):
+        return page
+
+    with patch.object(committees, "safe_committees_request", new=_se):
+        out = await committees.get_committee_nominations(
+            FakeContext(), committee_code="ssju00", limit=1)
+
+    assert "Description: A real nominee description." in out
+
+
+@pytest.mark.asyncio
+async def test_committee_nominations_tolerates_non_dict_nominee_entries():
+    page = {
+        "nominations": [
+            {
+                "citation": "PN4-1",
+                "congress": 119,
+                "number": 4,
+                "nominees": ["not-a-dict"],
+                "description": "Fallback description.",
+                "updateDate": "2026-01-01",
+                "url": "u",
+            },
+        ],
+        "pagination": {"count": 1},
+    }
+
+    async def _se(endpoint, ctx, params=None):
+        return page
+
+    with patch.object(committees, "safe_committees_request", new=_se):
+        out = await committees.get_committee_nominations(
+            FakeContext(), committee_code="ssju00", limit=1)
+
+    assert "Description: Fallback description." in out
+
+
+@pytest.mark.asyncio
+async def test_committee_nominations_whitespace_only_description_omitted():
+    page = {
+        "nominations": [
+            {
+                "citation": "PN5-1",
+                "congress": 119,
+                "number": 5,
+                "description": "   ",
+                "updateDate": "2026-01-01",
+                "url": "u",
+            },
+        ],
+        "pagination": {"count": 1},
+    }
+
+    async def _se(endpoint, ctx, params=None):
+        return page
+
+    with patch.object(committees, "safe_committees_request", new=_se):
+        out = await committees.get_committee_nominations(
+            FakeContext(), committee_code="ssju00", limit=1)
+
+    assert "Description:" not in out
+    assert "Nominees:" not in out

--- a/tests/test_issue_59_display_fixes.py
+++ b/tests/test_issue_59_display_fixes.py
@@ -1,0 +1,174 @@
+"""
+Regression tests for issue #59: cosmetic display bugs.
+
+- Hearings with the API's literal "NoChamber" token (joint/unassigned
+  committee hearings) rendered "Chamber: NoChamber" instead of a
+  human-readable label.
+- The committee-nominations listing rendered "Nominees: Unknown nominees"
+  for every row because it read a `nominees` array shape (firstName/
+  lastName) that only exists on the nomination *detail* endpoint; the
+  committee-level listing instead carries the nominee's name and
+  position in a `description` field.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import patch
+
+from congress_api.features import committees
+from congress_api.features.hearings import (
+    _display_chamber,
+    format_hearing_detail,
+    format_hearing_item,
+)
+
+
+class FakeContext:
+    pass
+
+
+# --- Hearing chamber display ---
+
+def test_display_chamber_maps_nochamber_to_joint():
+    assert _display_chamber("NoChamber") == "Joint"
+
+
+def test_display_chamber_passes_through_known_values():
+    assert _display_chamber("House") == "House"
+    assert _display_chamber("Senate") == "Senate"
+
+
+def test_display_chamber_defaults_missing_to_na():
+    assert _display_chamber(None) == "N/A"
+    assert _display_chamber("") == "N/A"
+
+
+def test_format_hearing_item_shows_joint_not_nochamber():
+    hearing = {
+        "chamber": "NoChamber",
+        "congress": 119,
+        "jacketNumber": 61499,
+        "updateDate": "2026-08-21T02:06:42Z",
+        "url": "https://api.congress.gov/v3/hearing/119/nochamber/61499",
+    }
+    out = format_hearing_item(hearing)
+    assert "Chamber: Joint" in out
+    assert "NoChamber" not in out
+
+
+def test_format_hearing_detail_shows_joint_not_nochamber():
+    hearing = {
+        "chamber": "NoChamber",
+        "title": "Intercepting Terror: Strengthening Ukrainian Air Defense",
+        "congress": 119,
+        "citation": "J.Hrg.119",
+        "jacketNumber": 61499,
+        "updateDate": "2026-08-21T02:06:42Z",
+    }
+    out = format_hearing_detail(hearing)
+    assert "Chamber: Joint" in out
+    assert "NoChamber" not in out
+
+
+def test_format_hearing_item_still_shows_house_and_senate():
+    house = format_hearing_item({"chamber": "House", "congress": 119,
+                                  "jacketNumber": 1, "updateDate": "d",
+                                  "url": "u"})
+    senate = format_hearing_item({"chamber": "Senate", "congress": 119,
+                                   "jacketNumber": 2, "updateDate": "d",
+                                   "url": "u"})
+    assert "Chamber: House" in house
+    assert "Chamber: Senate" in senate
+
+
+# --- Committee nominations nominee display ---
+
+_NOMINATIONS_PAGE = {
+    "nominations": [
+        {
+            "citation": "PN1201-7",
+            "congress": 119,
+            "description": (
+                "Jurgen Ryan Soekhoe, of the District of Columbia, to be "
+                "United States Marshal for the District of Columbia for "
+                "the term of four years, vice Patrick A. Burke, term "
+                "expired."
+            ),
+            "number": 1201,
+            "updateDate": "2026-07-22T11:00:26Z",
+            "url": "https://api.congress.gov/v3/nomination/119/1201-7",
+        },
+    ],
+    "pagination": {"count": 1},
+}
+
+
+@pytest.mark.asyncio
+async def test_committee_nominations_uses_description_not_unknown():
+    async def _se(endpoint, ctx, params=None):
+        return _NOMINATIONS_PAGE
+
+    with patch.object(committees, "safe_committees_request", new=_se):
+        out = await committees.get_committee_nominations(
+            FakeContext(), committee_code="ssju00", limit=1)
+
+    assert "Unknown nominees" not in out
+    assert "Description: Jurgen Ryan Soekhoe" in out
+
+
+@pytest.mark.asyncio
+async def test_committee_nominations_prefers_real_nominee_names():
+    page = {
+        "nominations": [
+            {
+                "citation": "PN1-1",
+                "congress": 119,
+                "number": 1,
+                "description": "Should not be shown when nominees present.",
+                "nominees": [{"firstName": "Jane", "lastName": "Doe"}],
+                "updateDate": "2026-01-01",
+                "url": "u",
+            },
+        ],
+        "pagination": {"count": 1},
+    }
+
+    async def _se(endpoint, ctx, params=None):
+        return page
+
+    with patch.object(committees, "safe_committees_request", new=_se):
+        out = await committees.get_committee_nominations(
+            FakeContext(), committee_code="ssju00", limit=1)
+
+    assert "Nominees: Jane Doe" in out
+    assert "Description:" not in out
+
+
+@pytest.mark.asyncio
+async def test_committee_nominations_omits_line_when_no_nominee_info():
+    page = {
+        "nominations": [
+            {
+                "citation": "PN2-1",
+                "congress": 119,
+                "number": 2,
+                "updateDate": "2026-01-01",
+                "url": "u",
+            },
+        ],
+        "pagination": {"count": 1},
+    }
+
+    async def _se(endpoint, ctx, params=None):
+        return page
+
+    with patch.object(committees, "safe_committees_request", new=_se):
+        out = await committees.get_committee_nominations(
+            FakeContext(), committee_code="ssju00", limit=1)
+
+    assert "Unknown nominees" not in out
+    assert "Nominees:" not in out
+    assert "Description:" not in out

--- a/tests/test_issue_59_display_fixes.py
+++ b/tests/test_issue_59_display_fixes.py
@@ -79,7 +79,8 @@ def test_format_hearing_item_shows_joint_not_nochamber():
     # Assert on the Chamber line specifically -- the fixture's own URL
     # legitimately contains "nochamber" in lowercase, so a bare
     # "NoChamber" absence check would pass even if the raw token leaked.
-    chamber_line = next(l for l in out.splitlines() if l.startswith("Chamber:"))
+    lines = out.splitlines()
+    chamber_line = next(line for line in lines if line.startswith("Chamber:"))
     assert chamber_line == "Chamber: Joint (nochamber)"
 
 
@@ -93,7 +94,8 @@ def test_format_hearing_detail_shows_joint_not_nochamber():
         "updateDate": "2026-08-21T02:06:42Z",
     }
     out = format_hearing_detail(hearing)
-    chamber_line = next(l for l in out.splitlines() if l.startswith("Chamber:"))
+    lines = out.splitlines()
+    chamber_line = next(line for line in lines if line.startswith("Chamber:"))
     assert chamber_line == "Chamber: Joint (nochamber)"
 
 

--- a/tests/test_issue_59_display_fixes.py
+++ b/tests/test_issue_59_display_fixes.py
@@ -33,7 +33,14 @@ class FakeContext:
 # --- Hearing chamber display ---
 
 def test_display_chamber_maps_nochamber_to_joint():
-    assert _display_chamber("NoChamber") == "Joint"
+    assert _display_chamber("NoChamber") == "Joint (nochamber)"
+
+
+def test_display_chamber_is_case_insensitive():
+    # The API uses lowercase "nochamber" in URLs/path params and the
+    # mixed-case "NoChamber" in JSON payload values -- both must map.
+    assert _display_chamber("nochamber") == "Joint (nochamber)"
+    assert _display_chamber("NOCHAMBER") == "Joint (nochamber)"
 
 
 def test_display_chamber_passes_through_known_values():
@@ -46,6 +53,19 @@ def test_display_chamber_defaults_missing_to_na():
     assert _display_chamber("") == "N/A"
 
 
+def test_display_chamber_keeps_nochamber_valid_for_round_trip():
+    # A client that copies the displayed chamber value back into
+    # get_hearings_by_congress_and_chamber/get_hearing_details must still
+    # find a value ParameterValidator.validate_chamber() accepts.
+    from congress_api.core.validators import ParameterValidator
+
+    displayed = _display_chamber("NoChamber")
+    assert "nochamber" in displayed.lower()
+    result = ParameterValidator.validate_chamber(
+        "nochamber", allow_nochamber=True)
+    assert result.is_valid
+
+
 def test_format_hearing_item_shows_joint_not_nochamber():
     hearing = {
         "chamber": "NoChamber",
@@ -55,8 +75,12 @@ def test_format_hearing_item_shows_joint_not_nochamber():
         "url": "https://api.congress.gov/v3/hearing/119/nochamber/61499",
     }
     out = format_hearing_item(hearing)
-    assert "Chamber: Joint" in out
-    assert "NoChamber" not in out
+    assert "Chamber: Joint (nochamber)" in out
+    # Assert on the Chamber line specifically -- the fixture's own URL
+    # legitimately contains "nochamber" in lowercase, so a bare
+    # "NoChamber" absence check would pass even if the raw token leaked.
+    chamber_line = next(l for l in out.splitlines() if l.startswith("Chamber:"))
+    assert chamber_line == "Chamber: Joint (nochamber)"
 
 
 def test_format_hearing_detail_shows_joint_not_nochamber():
@@ -69,8 +93,8 @@ def test_format_hearing_detail_shows_joint_not_nochamber():
         "updateDate": "2026-08-21T02:06:42Z",
     }
     out = format_hearing_detail(hearing)
-    assert "Chamber: Joint" in out
-    assert "NoChamber" not in out
+    chamber_line = next(l for l in out.splitlines() if l.startswith("Chamber:"))
+    assert chamber_line == "Chamber: Joint (nochamber)"
 
 
 def test_format_hearing_item_still_shows_house_and_senate():


### PR DESCRIPTION
## Summary
- \`records_and_hearings.get_hearings_by_congress(119)\` no longer renders
  \`Chamber: NoChamber\` — hearings held by joint (chamber-agnostic)
  committees now display \`Chamber: Joint (nochamber)\`.
- \`get_committee_nominations("ssju00")\` no longer renders
  \`Nominees: Unknown nominees\` for every row. The committee-level
  nominations listing (\`/committee/senate/{code}/nominations\`) never
  returns a \`nominees\` array with \`firstName\`/\`lastName\` — that shape
  only exists on the nomination *detail* endpoint. The listing instead
  carries the nominee's name and position embedded in a \`description\`
  field; the formatter now reads that, and omits the line entirely
  (instead of printing "Unknown") when neither is available. Verified
  live against the real Congress.gov API for both endpoints.
- Hardened the nominations formatter against messy API shapes found
  while fixing this: non-dict entries in \`nominees\`, whitespace-only
  \`description\`, and empty-but-present \`nominees: []\`.

## Assumptions Made
- "NoChamber" maps to "Joint": confirmed live against
  \`/hearing/119/nochamber/61499\`, a Helsinki Commission hearing with
  citation \`J.Hrg.119\` (a joint-committee citation prefix).
- Kept the raw API value in structured fields (\`HearingSummary.chamber\`,
  \`NominationSummary\`) unmapped/unmodified — only the human-readable
  text summary changed. This preserves round-trippability for machine
  consumers.
- Display value is \`"Joint (nochamber)"\` rather than bare \`"Joint"\`: an
  earlier draft used bare "Joint", but that broke the round trip back
  into \`get_hearings_by_congress_and_chamber\`/\`get_hearing_details\`,
  whose \`ParameterValidator.validate_chamber\` only accepts
  \`house\`/\`senate\`/\`nochamber\` (never \`joint\`). Keeping \`nochamber\`
  visible in the display lets a client self-correct.
- This repo has no \`CHANGELOG.md\`/\`changelog.d/\`; the \`docs/CHANGELOG.md\`
  referenced by the root CLAUDE.md lives in a separate git repository
  (\`congressMcpFiles\`), out of scope for this repo's commit history, so
  it was not updated here.

## Quality gates
- [x] All tests passing (1035 passed, 5 skipped, 22 subtests passed;
      2 pre-existing failures in \`test_registration_endpoint.py\` and 4
      pre-existing collection errors for removed
      \`congress_api.core.services\` module — both unrelated to this diff
      and present on \`master\`)
- [x] Lint clean (no new violations introduced; pre-existing whitespace/
      line-length issues in untouched code left as-is)
- [x] Code critique: PASS (88/100, two-iteration adversarial review —
      first pass caught a real chamber round-trip regression, fixed and
      re-verified)
- [x] No regressions

## Known Limitations
- The chamber label is not a single round-trippable token
  (\`"Joint (nochamber)"\` is not literally \`"nochamber"\`); a client
  copying the full displayed string back into \`get_hearing_details\`
  still needs to extract \`nochamber\`. Filing a follow-up to teach
  \`validate_chamber\` to accept \`"joint"\` as an alias.
- \`citation\` (e.g. \`PN1201-7\`) still isn't rendered in
  committee-nomination rows — pre-existing gap, out of scope here.

Closes #59