### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- `CONTRIBUTING.md` as the canonical source for code style, commit conventions, and the `documentation/` two-session model — resolves the conflicting commit-trailer guidance between `.claude/CLAUDE.md` and the workspace-level `CLAUDE.md` (#46, #78).
+- `tests/test_conventions_sync.py` guards `AGENTS.md` and `.claude/CLAUDE.md` against drifting apart.


### PR DESCRIPTION
## Summary
- Adds `CHANGELOG.md` — this repo had neither `changelog.d/` nor `CHANGELOG.md`, and the `/finish` docs-check for #46/#78 flagged a changelog record as required for every PR.
- Records the CONTRIBUTING.md consolidation (#46, #78) as the first `Unreleased` entry.

## Assumptions Made
- None — straight file addition following the standard `## Unreleased` / `### Added` format.

## Quality gates
- [x] Code critique: auto-pass (docs-only diff, single file, no workflow files)
- [x] No regressions (no code touched)

## Known Limitations
- None

Follow-up to #46 / #78.